### PR TITLE
Use external avatar url

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,7 +22,7 @@ repository               : "academicpages/academicpages.github.io"
 #               Additional customization can be done by editing /_includes/author-profile.html
 author:
   # Biographic information
-  avatar           : "profile.png"
+  avatar           : "http://www.commsp.ee.ic.ac.uk/~cling/wp-content/uploads/2015/08/Cong-200x300.jpg"
   name: "Cong Ling"
   pronouns         : # example: "she/her"  
   bio: "Professor in the Communications and Signal Processing Group"

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -7,7 +7,12 @@ redirect_from:
   - /about.html
 ---
 
-![Cong](http://www.commsp.ee.ic.ac.uk/~cling/wp-content/uploads/2015/08/Cong-200x300.jpg){: .alignright width="200" height="300"}
+{% include base_path %}
+{% if site.author.avatar contains '://' %}
+![Cong]({{ site.author.avatar }}){: .alignright width="200" height="300"}
+{% else %}
+![Cong]({{ base_path }}/images/{{ site.author.avatar }}){: .alignright width="200" height="300"}
+{% endif %}
 
 **Cong Ling** (凌聪)  
 [Communications and Signal Processing Group](http://www3.imperial.ac.uk/commssigproc)  

--- a/_pages/biography.md
+++ b/_pages/biography.md
@@ -5,7 +5,12 @@ permalink: /biography/
 author_profile: true
 ---
 
-![Cong](http://www.commsp.ee.ic.ac.uk/~cling/wp-content/uploads/2015/08/Cong-200x300.jpg){: .alignright width="200" height="300"}
+{% include base_path %}
+{% if site.author.avatar contains '://' %}
+![Cong]({{ site.author.avatar }}){: .alignright width="200" height="300"}
+{% else %}
+![Cong]({{ base_path }}/images/{{ site.author.avatar }}){: .alignright width="200" height="300"}
+{% endif %}
 
 **Cong Ling** (凌聪)  
 [Communications and Signal Processing Group](http://www3.imperial.ac.uk/commssigproc)  


### PR DESCRIPTION
## Summary
- update default avatar to the correct external link
- show the avatar on About and Biography pages using external or local paths

## Testing
- `git status --short`
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_684833b882b0832b930950195f84d80b