### PR TITLE
Add workflow for publications generation

### DIFF
--- a/.github/workflows/generate_publications.yml
+++ b/.github/workflows/generate_publications.yml
@@ -1,0 +1,32 @@
+name: Generate Publications
+
+on:
+  push:
+    paths:
+      - 'markdown_generator/publications.tsv'
+      - 'markdown_generator/publications.py'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+      - name: Install dependencies
+        run: |
+          pip install pandas
+      - name: Run publication generator
+        run: |
+          cd markdown_generator
+          python publications.py
+      - name: Commit changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add ../_publications/*.md || true
+          git commit -m "Automated update of publications" || echo "No changes to commit"
+          git push


### PR DESCRIPTION
## Summary
- automate markdown generation for publications

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6848376fb174832ba56e94ca0297b729