### PR TITLE
Add single line citation include

### DIFF
--- a/_includes/archive-single-line.html
+++ b/_includes/archive-single-line.html
@@ -1,0 +1,1 @@
+<li>{{ post.citation }}</li>

--- a/_pages/publications.html
+++ b/_pages/publications.html
@@ -21,15 +21,19 @@ author_profile: true
       {% endif %}
       {% unless title_shown %}
         <h2>{{ category[1].title }}</h2><hr />
+        <ul>
         {% assign title_shown = true %}
       {% endunless %}
-      {% include archive-single.html %}
+      {% include archive-single-line.html %}
     {% endfor %}
+    {% if title_shown %}</ul>{% endif %}
   {% endfor %}
 {% else %}
+  <ul>
   {% for post in site.publications reversed %}
-    {% include archive-single.html %}
+    {% include archive-single-line.html %}
   {% endfor %}
+  </ul>
 {% endif %}
 
 


### PR DESCRIPTION
## Summary
- add `archive-single-line.html` for one-line publication entries
- update `publications.html` to use the new include and wrap listings in `<ul>`

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848512edd94832b88a46fbe198d2f5a