### PR TITLE
Add missing categories in publications

### DIFF
--- a/_publications/2017-09-01-lyu-boosted-kz.md
+++ b/_publications/2017-09-01-lyu-boosted-kz.md
@@ -1,6 +1,7 @@
 ---
 title: "Boosted KZ and LLL Algorithms"
 collection: publications
+category: manuscripts
 permalink: /publication/lyu2017boosted
 date: 2017-09-01
 venue: 'IEEE Trans. Signal Processing'

--- a/_publications/2018-01-01-shi-heegard-berger.md
+++ b/_publications/2018-01-01-shi-heegard-berger.md
@@ -1,6 +1,7 @@
 ---
 title: "Polar Codes and Polar Lattices for the Heegard-Berger Problem"
 collection: publications
+category: manuscripts
 permalink: /publication/shi2018heegard
 date: 2018-01-01
 venue: 'IEEE Trans. Commun.'

--- a/_publications/2018-01-15-zheng-polar-cognitive.md
+++ b/_publications/2018-01-15-zheng-polar-cognitive.md
@@ -1,6 +1,7 @@
 ---
 title: "Polar Coding for the Cognitive Interference Channel with Confidential Messages"
 collection: publications
+category: manuscripts
 permalink: /publication/zheng2018cognitive
 date: 2018-01-15
 venue: 'IEEE J. Sel. Areas Commun.'

--- a/_publications/2018-02-01-zhang-atomic-norm.md
+++ b/_publications/2018-02-01-zhang-atomic-norm.md
@@ -1,6 +1,7 @@
 ---
 title: "Atomic Norm Denoising-Based Joint Channel Estimation and Faulty Antenna Detection for Massive MIMO"
 collection: publications
+category: manuscripts
 permalink: /publication/zhang2018atomic
 date: 2018-02-01
 venue: 'IEEE Trans. Veh. Tech.'

--- a/_publications/2018-02-02-wang-ergodicity.md
+++ b/_publications/2018-02-02-wang-ergodicity.md
@@ -1,6 +1,7 @@
 ---
 title: "On the Geometric Ergodicity of Metropolis-Hastings Algorithms for Lattice Gaussian Sampling"
 collection: publications
+category: manuscripts
 permalink: /publication/wang2018ergodicity
 date: 2018-02-02
 venue: 'IEEE Trans. Inform. Theory'

--- a/_publications/2018-03-01-zheng-secure-two-way.md
+++ b/_publications/2018-03-01-zheng-secure-two-way.md
@@ -1,6 +1,7 @@
 ---
 title: "Secure Polar Coding for the Two-Way Wiretap Channel"
 collection: publications
+category: manuscripts
 permalink: /publication/zheng2018twoway
 date: 2018-03-01
 venue: 'IEEE Access'

--- a/_publications/2018-03-05-liu-secrecy-capacity.md
+++ b/_publications/2018-03-05-liu-secrecy-capacity.md
@@ -1,6 +1,7 @@
 ---
 title: "Achieving Secrecy Capacity of the Gaussian Wiretap Channel with Polar Lattices"
 collection: publications
+category: manuscripts
 permalink: /publication/liu2018secrecy
 date: 2018-03-05
 venue: 'IEEE Trans. Inform. Theory'

--- a/_publications/2018-04-01-zhang-uniform-recovery.md
+++ b/_publications/2018-04-01-zhang-uniform-recovery.md
@@ -1,6 +1,7 @@
 ---
 title: "Uniform Recovery Bounds for Structured Random Matrices in Corrupted Compressed Sensing"
 collection: publications
+category: manuscripts
 permalink: /publication/zhang2018uniform
 date: 2018-04-01
 venue: 'IEEE Trans. Signal Processing'

--- a/_publications/2018-11-01-luzzi-wiretap.md
+++ b/_publications/2018-11-01-luzzi-wiretap.md
@@ -1,6 +1,7 @@
 ---
 title: "Almost universal codes for MIMO wiretap channels"
 collection: publications
+category: manuscripts
 permalink: /publication/luzzi2018wiretap
 date: 2018-11-01
 venue: 'IEEE Trans. Inform. Theory'

--- a/_publications/2018-12-01-campello-universal-lattice.md
+++ b/_publications/2018-12-01-campello-universal-lattice.md
@@ -1,6 +1,7 @@
 ---
 title: "Universal Lattice Codes for MIMO Channels"
 collection: publications
+category: manuscripts
 permalink: /publication/campello2018mimo
 date: 2018-12-01
 venue: 'IEEE Trans. Inform. Theory'

--- a/_publications/2019-01-01-lyu-hybrid-vector-perturbation.md
+++ b/_publications/2019-01-01-lyu-hybrid-vector-perturbation.md
@@ -1,6 +1,7 @@
 ---
 title: "Hybrid Vector Perturbation Precoding: The Blessing of Approximate Message Passing"
 collection: publications
+category: manuscripts
 permalink: /publication/lyu2019hybrid
 date: 2019-01-01
 venue: 'IEEE Trans. Signal Processing'

--- a/_publications/2019-02-01-liu-polar-lattices.md
+++ b/_publications/2019-02-01-liu-polar-lattices.md
@@ -1,6 +1,7 @@
 ---
 title: "Construction of capacity-achieving lattice codes: Polar lattices"
 collection: publications
+category: manuscripts
 permalink: /publication/liu2019polar-lattices
 date: 2019-02-01
 venue: 'IEEE Trans. Commun.'

--- a/_publications/2019-03-01-campello-awgn-goodness.md
+++ b/_publications/2019-03-01-campello-awgn-goodness.md
@@ -1,6 +1,7 @@
 ---
 title: "AWGN-Goodness is Enough: Capacity-Achieving Lattice Codes based on Dithered Probabilistic Shaping"
 collection: publications
+category: manuscripts
 permalink: /publication/campello2019awgn
 date: 2019-03-01
 venue: 'IEEE Trans. Inform. Theory'

--- a/_publications/2019-04-01-zheng-polar-interference.md
+++ b/_publications/2019-04-01-zheng-polar-interference.md
@@ -1,6 +1,7 @@
 ---
 title: "Polar Coding Strategies for the Interference Channel with Partial-Joint Decoding"
 collection: publications
+category: manuscripts
 permalink: /publication/zheng2019polarinterference
 date: 2019-04-01
 venue: 'IEEE Trans. Inform. Theory'

--- a/_publications/2019-06-01-li-coprime-sensing.md
+++ b/_publications/2019-06-01-li-coprime-sensing.md
@@ -1,6 +1,7 @@
 ---
 title: "Coprime Sensing via Chinese Remaindering over Quadratic Fields"
 collection: publications
+category: manuscripts
 permalink: /publication/li2019coprime
 date: 2019-06-01
 venue: 'IEEE Trans. Signal Processing'

--- a/_publications/2019-06-01-wang-lattice-gaussian-sampling.md
+++ b/_publications/2019-06-01-wang-lattice-gaussian-sampling.md
@@ -1,6 +1,7 @@
 ---
 title: "Lattice Gaussian Sampling by Markov Chain Monte Carlo: Bounded Distance Decoding and Trapdoor Sampling"
 collection: publications
+category: manuscripts
 permalink: /publication/wang2019lattice
 date: 2019-06-01
 venue: 'IEEE Trans. Inform. Theory'

--- a/_publications/2019-11-01-lyu-ring-compute-and-forward.md
+++ b/_publications/2019-11-01-lyu-ring-compute-and-forward.md
@@ -1,6 +1,7 @@
 ---
 title: "Ring Compute-and-Forward over Block-Fading Channels"
 collection: publications
+category: manuscripts
 permalink: /publication/lyu2019ring
 date: 2019-11-01
 venue: 'IEEE Trans. Inform. Theory'


### PR DESCRIPTION
## Summary
- add `category: manuscripts` to publication markdown files missing the field

## Testing
- `bundle install` *(fails: 403 Forbidden)*
- `bundle exec jekyll build` *(not run due to missing gems)*

------
https://chatgpt.com/codex/tasks/task_e_684863764270832ba0396aac4b7c5afe