### PR TITLE
Fix publication categories

### DIFF
--- a/_publications/1900-01-01-multi-dimensional-nested-lattice-quantization-for-wyner-ziv-coding.md
+++ b/_publications/1900-01-01-multi-dimensional-nested-lattice-quantization-for-wyner-ziv-coding.md
@@ -1,0 +1,10 @@
+---
+title: "Multi-dimensional nested lattice quantization for Wyner-Ziv coding"
+collection: publications
+category: conferences
+permalink: /publication/multi-dimensional-nested-lattice-quantization-for-wyner-ziv-coding
+date: 1900-01-01
+venue: 'ICC’09'
+paperurl: ''
+citation: 'Su Gao and Cong Ling "<a href=''>Multi-dimensional nested lattice quantization for Wyner-Ziv coding</a>", ICC’09, Dresden, Germany.'
+---

--- a/_publications/1900-01-01-near-optimal-relaying-strategy-for-cooperative-broadcast-channel.md
+++ b/_publications/1900-01-01-near-optimal-relaying-strategy-for-cooperative-broadcast-channel.md
@@ -1,0 +1,10 @@
+---
+title: "Near-optimal relaying strategy for cooperative broadcast channel"
+collection: publications
+category: conferences
+permalink: /publication/near-optimal-relaying-strategy-for-cooperative-broadcast-channel
+date: 1900-01-01
+venue: 'ICC’09'
+paperurl: ''
+citation: 'Haishi Ning, Cong Ling and Kin Leung "<a href=''>Near-optimal relaying strategy for cooperative broadcast channel</a>", ICC’09, Dresden, Germany.'
+---

--- a/_publications/1998-01-01-chaotic-frequency-hopping-sequences.md
+++ b/_publications/1998-01-01-chaotic-frequency-hopping-sequences.md
@@ -1,0 +1,10 @@
+---
+title: "Chaotic frequency hopping sequences"
+collection: publications
+category: manuscripts
+permalink: /publication/chaotic-frequency-hopping-sequences
+date: 1998-01-01
+venue: 'IEEE Trans. Commun.'
+paperurl: ''
+citation: 'Ling Cong and Sun Songgeng "<a href=''>Chaotic frequency hopping sequences</a>", IEEE Trans. Commun., vol. 46, pp. 1433-1437, Nov. 1998.'
+---

--- a/_publications/1999-01-01-a-general-efficient-method-for-chaotic-signal-estimation.md
+++ b/_publications/1999-01-01-a-general-efficient-method-for-chaotic-signal-estimation.md
@@ -1,0 +1,10 @@
+---
+title: "A general efficient method for chaotic signal estimation"
+collection: publications
+category: manuscripts
+permalink: /publication/a-general-efficient-method-for-chaotic-signal-estimation
+date: 1999-01-01
+venue: 'IEEE Trans. Signal Processing'
+paperurl: ''
+citation: 'Ling Cong, Wu Xiaofu and Sun Songgeng "<a href=''>A general efficient method for chaotic signal estimation</a>", IEEE Trans. Signal Processing, vol. 47, pp. 1424-1427, May 1999.'
+---

--- a/_publications/1999-01-01-data-aided-phase-tracking-detection-of-frequency-shifted-dpsk-signals-with-baseband-frequency-drift-compensation.md
+++ b/_publications/1999-01-01-data-aided-phase-tracking-detection-of-frequency-shifted-dpsk-signals-with-baseband-frequency-drift-compensation.md
@@ -1,0 +1,10 @@
+---
+title: "Data-aided phase tracking detection of frequency-shifted DPSK signals with baseband frequency-drift compensation"
+collection: publications
+category: manuscripts
+permalink: /publication/data-aided-phase-tracking-detection-of-frequency-shifted-dpsk-signals-with-baseband-frequency-drift-compensation
+date: 1999-01-01
+venue: 'Electron. Lett.'
+paperurl: ''
+citation: 'Xiaofu Wu, Cong Ling and Songgeng Sun "<a href=''>Data-aided phase tracking detection of frequency-shifted DPSK signals with baseband frequency-drift compensation</a>", Electron. Lett., vol.35, no.15, pp. 1222-1223, July 1999.'
+---

--- a/_publications/1999-01-01-on-sova-for-nonbinary-codes.md
+++ b/_publications/1999-01-01-on-sova-for-nonbinary-codes.md
@@ -1,0 +1,10 @@
+---
+title: "On SOVA for nonbinary codes"
+collection: publications
+category: manuscripts
+permalink: /publication/on-sova-for-nonbinary-codes
+date: 1999-01-01
+venue: 'IEEE Commun. Lett.'
+paperurl: ''
+citation: 'Ling Cong, Wu Xiaofu and Yi Xiaoxin "<a href=''>On SOVA for nonbinary codes</a>", IEEE Commun. Lett., vol. 3, pp. 335-337, Dec. 1999.'
+---

--- a/_publications/2000-01-01-chaotic-spreading-sequences-with-multiple-access-performance-better-than-random-sequences.md
+++ b/_publications/2000-01-01-chaotic-spreading-sequences-with-multiple-access-performance-better-than-random-sequences.md
@@ -1,0 +1,10 @@
+---
+title: "Chaotic spreading sequences with multiple access performance better than random sequences"
+collection: publications
+category: manuscripts
+permalink: /publication/chaotic-spreading-sequences-with-multiple-access-performance-better-than-random-sequences
+date: 2000-01-01
+venue: 'IEEE Trans. CAS-I'
+paperurl: ''
+citation: 'Ling Cong and Li Shaoqian "<a href=''>Chaotic spreading sequences with multiple access performance better than random sequences</a>", IEEE Trans. CAS-I, vol. 47, pp. 394-397, Mar. 2000.'
+---

--- a/_publications/2001-01-01-design-and-implementation-of-an-fpga-based-generator-for-chaotic-frequency-hopping-sequences.md
+++ b/_publications/2001-01-01-design-and-implementation-of-an-fpga-based-generator-for-chaotic-frequency-hopping-sequences.md
@@ -1,0 +1,10 @@
+---
+title: "Design and implementation of an FPGA-based generator for chaotic frequency hopping sequences"
+collection: publications
+category: manuscripts
+permalink: /publication/design-and-implementation-of-an-fpga-based-generator-for-chaotic-frequency-hopping-sequences
+date: 2001-01-01
+venue: 'IEEE Trans. CAS-I'
+paperurl: ''
+citation: 'Ling Cong and Wu Xiaofu "<a href=''>Design and implementation of an FPGA-based generator for chaotic frequency hopping sequences</a>", IEEE Trans. CAS-I, vol. 48, pp. 521-532, May 2001.'
+---

--- a/_publications/2001-01-01-family-size-of-orthogonal-oppermann-sequences.md
+++ b/_publications/2001-01-01-family-size-of-orthogonal-oppermann-sequences.md
@@ -1,0 +1,10 @@
+---
+title: "Family size of orthogonal Oppermann sequences"
+collection: publications
+category: manuscripts
+permalink: /publication/family-size-of-orthogonal-oppermann-sequences
+date: 2001-01-01
+venue: 'Electron. Lett.'
+paperurl: ''
+citation: 'Guozhen Zang and Cong Ling "<a href=''>Family size of orthogonal Oppermann sequences</a>", Electron. Lett., vol. 37, pp. 631-632, May 2001.'
+---

--- a/_publications/2002-01-01-despreading-chip-waveform-design-for-coherent-delay-locked-tracking-in-ds-ss-systems.md
+++ b/_publications/2002-01-01-despreading-chip-waveform-design-for-coherent-delay-locked-tracking-in-ds-ss-systems.md
@@ -1,0 +1,10 @@
+---
+title: "Despreading chip waveform design for coherent delay-locked tracking in DS/SS systems"
+collection: publications
+category: conferences
+permalink: /publication/despreading-chip-waveform-design-for-coherent-delay-locked-tracking-in-ds-ss-systems
+date: 2002-01-01
+venue: 'in Proc. ICC’2002'
+paperurl: ''
+citation: 'Xiaofu Wu, Cong Ling and Haige Xiang "<a href=''>Despreading chip waveform design for coherent delay-locked tracking in DS/SS systems</a>", in Proc. ICC’2002, New York.'
+---

--- a/_publications/2002-01-01-linear-prediction-receiver-for-differential-space-time-modulation-over-time-correlated-rayleigh-fading-channels.md
+++ b/_publications/2002-01-01-linear-prediction-receiver-for-differential-space-time-modulation-over-time-correlated-rayleigh-fading-channels.md
@@ -1,0 +1,10 @@
+---
+title: "Linear prediction receiver for differential space-time modulation over time-correlated Rayleigh fading channels"
+collection: publications
+category: conferences
+permalink: /publication/linear-prediction-receiver-for-differential-space-time-modulation-over-time-correlated-rayleigh-fading-channels
+date: 2002-01-01
+venue: 'in Proc. ICC’2002'
+paperurl: ''
+citation: 'Cong Ling and Xiaofu Wu "<a href=''>Linear prediction receiver for differential space-time modulation over time-correlated Rayleigh fading channels</a>", in Proc. ICC’2002, New York.'
+---

--- a/_publications/2003-01-01-decision-feedback-multiple-symbol-differential-detection-of-differential-space-time-modulation-in-continuously-fading-channels.md
+++ b/_publications/2003-01-01-decision-feedback-multiple-symbol-differential-detection-of-differential-space-time-modulation-in-continuously-fading-channels.md
@@ -1,0 +1,10 @@
+---
+title: "Decision-feedback multiple symbol differential detection of differential space-time modulation in continuously fading channels"
+collection: publications
+category: manuscripts
+permalink: /publication/decision-feedback-multiple-symbol-differential-detection-of-differential-space-time-modulation-in-continuously-fading-channels
+date: 2003-01-01
+venue: 'in Proc. ICASSP’03'
+paperurl: ''
+citation: 'Cong Ling, K. H. Li and A. C. Kot "<a href=''>Decision-feedback multiple symbol differential detection of differential space-time modulation in continuously fading channels</a>", in Proc. ICASSP’03, Hong Kong, China, May 2003, pp. IV_45–IV_48.'
+---

--- a/_publications/2003-01-01-multisampling-decision-feedback-linear-prediction-receivers-for-differential-space-time-modulation-over-rayleigh-fast-fading-channels.md
+++ b/_publications/2003-01-01-multisampling-decision-feedback-linear-prediction-receivers-for-differential-space-time-modulation-over-rayleigh-fast-fading-channels.md
@@ -1,0 +1,10 @@
+---
+title: "Multisampling decision-feedback linear prediction receivers for differential space-time modulation over Rayleigh fast fading channels"
+collection: publications
+category: manuscripts
+permalink: /publication/multisampling-decision-feedback-linear-prediction-receivers-for-differential-space-time-modulation-over-rayleigh-fast-fading-channels
+date: 2003-01-01
+venue: 'IEEE Trans. Commun.'
+paperurl: ''
+citation: 'Cong Ling, K. H. Li, A. C. Kot, and Q. T. Zhang "<a href=''>Multisampling decision-feedback linear prediction receivers for differential space-time modulation over Rayleigh fast fading channels</a>", IEEE Trans. Commun., vol. 51, pp. 1214-1223, July 2003.'
+---

--- a/_publications/2003-01-01-noncoherent-sequence-detection-of-differential-space-time-modulation.md
+++ b/_publications/2003-01-01-noncoherent-sequence-detection-of-differential-space-time-modulation.md
@@ -1,0 +1,10 @@
+---
+title: "Noncoherent sequence detection of differential space-time modulation"
+collection: publications
+category: manuscripts
+permalink: /publication/noncoherent-sequence-detection-of-differential-space-time-modulation
+date: 2003-01-01
+venue: 'IEEE Trans. Inform. Theory'
+paperurl: ''
+citation: 'Cong Ling, K. H. Li and A. C. Kot "<a href=''>Noncoherent sequence detection of differential space-time modulation</a>", IEEE Trans. Inform. Theory, vol.49, pp. 2727-2734, Oct. 2003.'
+---

--- a/_publications/2003-01-01-on-decision-feedback-detection-of-nondiagonal-differential-space-time-modulation-in-temporally-correlated-fading-channels.md
+++ b/_publications/2003-01-01-on-decision-feedback-detection-of-nondiagonal-differential-space-time-modulation-in-temporally-correlated-fading-channels.md
@@ -1,0 +1,10 @@
+---
+title: "On Decision-Feedback Detection of Nondiagonal Differential Space-Time Modulation in Temporally Correlated Fading Channels"
+collection: publications
+category: conferences
+permalink: /publication/on-decision-feedback-detection-of-nondiagonal-differential-space-time-modulation-in-temporally-correlated-fading-channels
+date: 2003-01-01
+venue: 'in Proc. ICC’03'
+paperurl: ''
+citation: 'Cong Ling, K. H. Li and A. C. Kot "<a href=''>On Decision-Feedback Detection of Nondiagonal Differential Space-Time Modulation in Temporally Correlated Fading Channels</a>", in Proc. ICC’03, Anchorage, AL, May 2003, pp. 2648–2652.'
+---

--- a/_publications/2003-01-01-performance-evaluation-for-bandlimited-ds-cdma-systems-based-on-simplified-improved-gaussian-approximation.md
+++ b/_publications/2003-01-01-performance-evaluation-for-bandlimited-ds-cdma-systems-based-on-simplified-improved-gaussian-approximation.md
@@ -1,0 +1,10 @@
+---
+title: "Performance evaluation for bandlimited DS-CDMA systems based on simplified improved Gaussian approximation"
+collection: publications
+category: manuscripts
+permalink: /publication/performance-evaluation-for-bandlimited-ds-cdma-systems-based-on-simplified-improved-gaussian-approximation
+date: 2003-01-01
+venue: 'IEEE Trans. Commun.'
+paperurl: ''
+citation: 'Guozhen Zang and Cong Ling "<a href=''>Performance evaluation for bandlimited DS-CDMA systems based on simplified improved Gaussian approximation</a>", IEEE Trans. Commun., vol. 51, pp. 1204-1213, July 2003.'
+---

--- a/_publications/2004-01-01-gallager-bounds-for-space-time-codes.md
+++ b/_publications/2004-01-01-gallager-bounds-for-space-time-codes.md
@@ -1,0 +1,10 @@
+---
+title: "Gallager bounds for space-time codes"
+collection: publications
+category: conferences
+permalink: /publication/gallager-bounds-for-space-time-codes
+date: 2004-01-01
+venue: 'IEEE Communication Theory Workshop 2004'
+paperurl: ''
+citation: 'Cong Ling, K. H. Li and A. C. Kot "<a href=''>Gallager bounds for space-time codes</a>", IEEE Communication Theory Workshop 2004, Capri, Italy, May 2004.'
+---

--- a/_publications/2004-01-01-on-decision-feedback-detection-of-differential-space-time-modulation-in-continuous-fading.md
+++ b/_publications/2004-01-01-on-decision-feedback-detection-of-differential-space-time-modulation-in-continuous-fading.md
@@ -1,0 +1,10 @@
+---
+title: "On decision-feedback detection of differential space-time modulation in continuous fading"
+collection: publications
+category: manuscripts
+permalink: /publication/on-decision-feedback-detection-of-differential-space-time-modulation-in-continuous-fading
+date: 2004-01-01
+venue: 'IEEE Trans. Commun.'
+paperurl: ''
+citation: 'Cong Ling, K. H. Li and A. C. Kot "<a href=''>On decision-feedback detection of differential space-time modulation in continuous fading</a>", IEEE Trans. Commun., vol. 52, pp. 1613-1617, Oct. 2004.'
+---

--- a/_publications/2005-01-01-differential-lattice-decoding-in-noncoherent-mimo-communication.md
+++ b/_publications/2005-01-01-differential-lattice-decoding-in-noncoherent-mimo-communication.md
@@ -1,0 +1,10 @@
+---
+title: "Differential lattice decoding in noncoherent MIMO communication"
+collection: publications
+category: conferences
+permalink: /publication/differential-lattice-decoding-in-noncoherent-mimo-communication
+date: 2005-01-01
+venue: 'ICC’05'
+paperurl: ''
+citation: 'Cong Ling, W. H. Mow, K. H. Li and A. C. Kot "<a href=''>Differential lattice decoding in noncoherent MIMO communication</a>", ICC’05, Seoul, Korea, May 2005.'
+---

--- a/_publications/2005-01-01-multiple-antenna-differential-lattice-decoding.md
+++ b/_publications/2005-01-01-multiple-antenna-differential-lattice-decoding.md
@@ -1,0 +1,10 @@
+---
+title: "Multiple-Antenna differential lattice decoding"
+collection: publications
+category: manuscripts
+permalink: /publication/multiple-antenna-differential-lattice-decoding
+date: 2005-01-01
+venue: 'IEEE J-SAC'
+paperurl: ''
+citation: 'Cong Ling, W. H. Mow, K. H. Li and A. C. Kot "<a href=''>Multiple-Antenna differential lattice decoding</a>", IEEE J-SAC, vol. 23, pp.1821-1829, Sept. 2005.'
+---

--- a/_publications/2006-01-01-a-dual-lattice-view-of-v-blast-detection.md
+++ b/_publications/2006-01-01-a-dual-lattice-view-of-v-blast-detection.md
@@ -1,0 +1,10 @@
+---
+title: "A dual-lattice view of V-BLAST detection"
+collection: publications
+category: conferences
+permalink: /publication/a-dual-lattice-view-of-v-blast-detection
+date: 2006-01-01
+venue: 'IEEE Inform. Theory Workshop'
+paperurl: ''
+citation: 'Cong Ling, Lu Gan, and Wai Ho Mow "<a href=''>A dual-lattice view of V-BLAST detection</a>", IEEE Inform. Theory Workshop, Chengdu, China, Oct. 2006.'
+---

--- a/_publications/2006-01-01-approximate-lattice-decoding-primal-versus-dual-basis-reduction.md
+++ b/_publications/2006-01-01-approximate-lattice-decoding-primal-versus-dual-basis-reduction.md
@@ -1,0 +1,10 @@
+---
+title: "Approximate lattice decoding: Primal versus dual basis reduction"
+collection: publications
+category: conferences
+permalink: /publication/approximate-lattice-decoding-primal-versus-dual-basis-reduction
+date: 2006-01-01
+venue: 'IEEE Int. Symp. Inform. Theory’06'
+paperurl: ''
+citation: 'Cong Ling "<a href=''>Approximate lattice decoding: Primal versus dual basis reduction</a>", IEEE Int. Symp. Inform. Theory’06, Seattle, July 2006.'
+---

--- a/_publications/2006-01-01-bounds-on-the-decoding-error-probability-of-binary-block-codes-over-noncoherent-block-awgn-and-fading-channels.md
+++ b/_publications/2006-01-01-bounds-on-the-decoding-error-probability-of-binary-block-codes-over-noncoherent-block-awgn-and-fading-channels.md
@@ -1,0 +1,10 @@
+---
+title: "Bounds on the decoding error probability of binary block codes over noncoherent block AWGN and fading channels"
+collection: publications
+category: manuscripts
+permalink: /publication/bounds-on-the-decoding-error-probability-of-binary-block-codes-over-noncoherent-block-awgn-and-fading-channels
+date: 2006-01-01
+venue: 'IEEE Trans. Wireless Commun.'
+paperurl: ''
+citation: 'Xiaofu Wu, Haige Xiang, Cong Ling, Xiaohu You, and Shaoqian Li "<a href=''>Bounds on the decoding error probability of binary block codes over noncoherent block AWGN and fading channels</a>", IEEE Trans. Wireless Commun., vol. 5, pp. 3193-3203, Nov. 2006.'
+---

--- a/_publications/2006-01-01-gallager-bounds-for-space-time-codes-in-quasi-static-fading-channels.md
+++ b/_publications/2006-01-01-gallager-bounds-for-space-time-codes-in-quasi-static-fading-channels.md
@@ -1,0 +1,10 @@
+---
+title: "Gallager bounds for space-time codes in quasi-static fading channels"
+collection: publications
+category: conferences
+permalink: /publication/gallager-bounds-for-space-time-codes-in-quasi-static-fading-channels
+date: 2006-01-01
+venue: 'IEEE Inform. Theory Workshop'
+paperurl: ''
+citation: 'Cong Ling "<a href=''>Gallager bounds for space-time codes in quasi-static fading channels</a>", IEEE Inform. Theory Workshop, Oct. 2006.'
+---

--- a/_publications/2006-01-01-towards-characterizing-the-performance-of-approximate-lattice-decoding-in-mimo-communications.md
+++ b/_publications/2006-01-01-towards-characterizing-the-performance-of-approximate-lattice-decoding-in-mimo-communications.md
@@ -1,0 +1,10 @@
+---
+title: "Towards characterizing the performance of approximate lattice decoding in MIMO communications"
+collection: publications
+category: conferences
+permalink: /publication/towards-characterizing-the-performance-of-approximate-lattice-decoding-in-mimo-communications
+date: 2006-01-01
+venue: 'Int. Symp. Turbo Codes / Int. ITG Conf. Source Channel Coding’06'
+paperurl: ''
+citation: 'Cong Ling "<a href=''>Towards characterizing the performance of approximate lattice decoding in MIMO communications</a>", Int. Symp. Turbo Codes / Int. ITG Conf. Source Channel Coding’06, Munich, Germany, Apr. 2006.'
+---

--- a/_publications/2007-01-01-computation-of-the-dual-frame-forward-and-backward-greville-formulas.md
+++ b/_publications/2007-01-01-computation-of-the-dual-frame-forward-and-backward-greville-formulas.md
@@ -1,0 +1,10 @@
+---
+title: "Computation of the dual frame: Forward and backward Greville formulas"
+collection: publications
+category: manuscripts
+permalink: /publication/computation-of-the-dual-frame-forward-and-backward-greville-formulas
+date: 2007-01-01
+venue: 'IEEE ICASSP 2007.'
+paperurl: ''
+citation: 'Lu Gan and Cong Ling "<a href=''>Computation of the dual frame: Forward and backward Greville formulas</a>", IEEE ICASSP 2007.'
+---

--- a/_publications/2007-01-01-effective-lll-reduction-for-lattice-decoding.md
+++ b/_publications/2007-01-01-effective-lll-reduction-for-lattice-decoding.md
@@ -1,0 +1,10 @@
+---
+title: "Effective LLL reduction for lattice decoding"
+collection: publications
+category: conferences
+permalink: /publication/effective-lll-reduction-for-lattice-decoding
+date: 2007-01-01
+venue: 'IEEE Int. Symp. Inform. Theory’07'
+paperurl: ''
+citation: 'Cong Ling and Nick Howgrave-Graham "<a href=''>Effective LLL reduction for lattice decoding</a>", IEEE Int. Symp. Inform. Theory’07, Nice, France, June 2007.'
+---

--- a/_publications/2007-01-01-gallager-bounds-for-noncoherent-decoders-in-fading-channels.md
+++ b/_publications/2007-01-01-gallager-bounds-for-noncoherent-decoders-in-fading-channels.md
@@ -1,0 +1,10 @@
+---
+title: "Gallager bounds for noncoherent decoders in fading channels"
+collection: publications
+category: manuscripts
+permalink: /publication/gallager-bounds-for-noncoherent-decoders-in-fading-channels
+date: 2007-01-01
+venue: 'IEEE Trans. Inform. Theory'
+paperurl: ''
+citation: 'Cong Ling, Xiaofu Wu, K. H. Li, and A. C. Kot "<a href=''>Gallager bounds for noncoherent decoders in fading channels</a>", IEEE Trans. Inform. Theory, vol. 53, pp. 4605-4614, Dec. 2007.'
+---

--- a/_publications/2007-01-01-generalized-union-bound-for-space-time-codes.md
+++ b/_publications/2007-01-01-generalized-union-bound-for-space-time-codes.md
@@ -1,0 +1,10 @@
+---
+title: "Generalized union bound for space-time codes"
+collection: publications
+category: manuscripts
+permalink: /publication/generalized-union-bound-for-space-time-codes
+date: 2007-01-01
+venue: 'IEEE Trans. Commun.'
+paperurl: ''
+citation: 'Cong Ling "<a href=''>Generalized union bound for space-time codes</a>", IEEE Trans. Commun., vol. 55, pp. 90-99, Jan. 2007.'
+---

--- a/_publications/2007-01-01-new-gallager-bounds-in-block-fading-channels.md
+++ b/_publications/2007-01-01-new-gallager-bounds-in-block-fading-channels.md
@@ -1,0 +1,10 @@
+---
+title: "New Gallager bounds in block fading channels"
+collection: publications
+category: manuscripts
+permalink: /publication/new-gallager-bounds-in-block-fading-channels
+date: 2007-01-01
+venue: 'IEEE Trans. Inform. Theory'
+paperurl: ''
+citation: 'Xiaofu Wu, Haige Xiang and Cong Ling "<a href=''>New Gallager bounds in block fading channels</a>", IEEE Trans. Inform. Theory, vol. 53, pp. 684-694, Feb. 2007.'
+---

--- a/_publications/2007-01-01-on-complex-lll-algorithm-for-digital-communications.md
+++ b/_publications/2007-01-01-on-complex-lll-algorithm-for-digital-communications.md
@@ -1,0 +1,10 @@
+---
+title: "On complex LLL algorithm for digital communications"
+collection: publications
+category: manuscripts
+permalink: /publication/on-complex-lll-algorithm-for-digital-communications
+date: 2007-01-01
+venue: 'LLL+25 Conference'
+paperurl: ''
+citation: 'Cong Ling and Wai Ho Mow "<a href=''>On complex LLL algorithm for digital communications</a>", LLL+25 Conference, Caen, France, June-July 2007.'
+---

--- a/_publications/2007-01-01-towards-understanding-weighted-bit-flipping-decoding.md
+++ b/_publications/2007-01-01-towards-understanding-weighted-bit-flipping-decoding.md
@@ -1,0 +1,10 @@
+---
+title: "Towards understanding weighted bit-flipping decoding"
+collection: publications
+category: conferences
+permalink: /publication/towards-understanding-weighted-bit-flipping-decoding
+date: 2007-01-01
+venue: 'IEEE Int. Symp. Inform. Theory’07'
+paperurl: ''
+citation: 'Xiaofu Wu, Cong Ling et al. "<a href=''>Towards understanding weighted bit-flipping decoding</a>", IEEE Int. Symp. Inform. Theory’07, Nice, France, June 2007.'
+---

--- a/_publications/2008-01-01-a-back-iteration-method-for-reconstructing-chaotic-sequences-in-finite-precision-machines.md
+++ b/_publications/2008-01-01-a-back-iteration-method-for-reconstructing-chaotic-sequences-in-finite-precision-machines.md
@@ -1,0 +1,10 @@
+---
+title: "A back-iteration method for reconstructing chaotic sequences in finite-precision machines"
+collection: publications
+category: manuscripts
+permalink: /publication/a-back-iteration-method-for-reconstructing-chaotic-sequences-in-finite-precision-machines
+date: 2008-01-01
+venue: 'Circuits'
+paperurl: ''
+citation: 'Cong Ling and Xiaofu Wu "<a href=''>A back-iteration method for reconstructing chaotic sequences in finite-precision machines</a>", Circuits, Syst., Signal Processing, vol. 27, pp. 883 – 891, Oct. 2008.'
+---

--- a/_publications/2008-01-01-computation-of-the-para-pseudo-inverse-for-oversampled-filter-banks-forward-and-backward-greville-formulas.md
+++ b/_publications/2008-01-01-computation-of-the-para-pseudo-inverse-for-oversampled-filter-banks-forward-and-backward-greville-formulas.md
@@ -1,0 +1,10 @@
+---
+title: "Computation of the Para-Pseudo Inverse for Oversampled Filter Banks: Forward and Backward Greville Formulas"
+collection: publications
+category: manuscripts
+permalink: /publication/computation-of-the-para-pseudo-inverse-for-oversampled-filter-banks-forward-and-backward-greville-formulas
+date: 2008-01-01
+venue: 'IEEE Trans. Signal Processing'
+paperurl: ''
+citation: 'Lu Gan and Cong Ling "<a href=''>Computation of the Para-Pseudo Inverse for Oversampled Filter Banks: Forward and Backward Greville Formulas</a>", IEEE Trans. Signal Processing, vol. 56, pp. 5851 – 5860, Dec. 2008.'
+---

--- a/_publications/2008-01-01-performance-of-space-time-codes-gallager-bounds-and-weight-enumeration.md
+++ b/_publications/2008-01-01-performance-of-space-time-codes-gallager-bounds-and-weight-enumeration.md
@@ -1,0 +1,10 @@
+---
+title: "Performance of space-time codes: Gallager bounds and weight enumeration"
+collection: publications
+category: manuscripts
+permalink: /publication/performance-of-space-time-codes-gallager-bounds-and-weight-enumeration
+date: 2008-01-01
+venue: 'IEEE Trans. Inform. Theory'
+paperurl: ''
+citation: 'Cong Ling, K. H. Li and A. C. Kot "<a href=''>Performance of space-time codes: Gallager bounds and weight enumeration</a>", IEEE Trans. Inform. Theory, vol. 54, pp. 3592-3610, Aug. 2008.'
+---

--- a/_publications/2009-01-01-a-unified-view-of-sorting-in-lattice-reduction-from-v-blast-to-lll-and-beyond.md
+++ b/_publications/2009-01-01-a-unified-view-of-sorting-in-lattice-reduction-from-v-blast-to-lll-and-beyond.md
@@ -1,0 +1,10 @@
+---
+title: "A unified view of sorting in lattice reduction: From V-BLAST to LLL and beyond"
+collection: publications
+category: conferences
+permalink: /publication/a-unified-view-of-sorting-in-lattice-reduction-from-v-blast-to-lll-and-beyond
+date: 2009-01-01
+venue: 'IEEE Inform. Theory Workshop 2009'
+paperurl: ''
+citation: 'Cong Ling and Wai Ho Mow "<a href=''>A unified view of sorting in lattice reduction: From V-BLAST to LLL and beyond</a>", IEEE Inform. Theory Workshop 2009, Taormina, Italy.'
+---

--- a/_publications/2009-01-01-active-physical-layer-network-coding-for-cooperative-two-way-relay-channels.md
+++ b/_publications/2009-01-01-active-physical-layer-network-coding-for-cooperative-two-way-relay-channels.md
@@ -1,0 +1,10 @@
+---
+title: "Active physical-layer network coding for cooperative two-way relay channels"
+collection: publications
+category: conferences
+permalink: /publication/active-physical-layer-network-coding-for-cooperative-two-way-relay-channels
+date: 2009-01-01
+venue: 'Second IEEE International Workshop on Wireless Network Coding'
+paperurl: ''
+citation: 'Haishi Ning, Cong Ling and Kin Leung "<a href=''>Active physical-layer network coding for cooperative two-way relay channels</a>", Second IEEE International Workshop on Wireless Network Coding, Rome, Italy, 2009.'
+---

--- a/_publications/2009-01-01-complex-lattice-reduction-algorithm-for-low-complexity-full-diversity-mimo-detection.md
+++ b/_publications/2009-01-01-complex-lattice-reduction-algorithm-for-low-complexity-full-diversity-mimo-detection.md
@@ -1,0 +1,10 @@
+---
+title: "Complex lattice reduction algorithm for low-complexity full-diversity MIMO detection"
+collection: publications
+category: manuscripts
+permalink: /publication/complex-lattice-reduction-algorithm-for-low-complexity-full-diversity-mimo-detection
+date: 2009-01-01
+venue: 'IEEE Trans. Signal Processing'
+paperurl: ''
+citation: 'Ying Hung Gan, Cong Ling, and Wai Ho Mow "<a href=''>Complex lattice reduction algorithm for low-complexity full-diversity MIMO detection</a>", IEEE Trans. Signal Processing, vol. 57, pp. 2701-2710, July 2009. MATLAB code for CLLL.'
+---

--- a/_publications/2009-01-01-dual-lattice-algorithm-and-partial-lattice-reduction-for-sic-based-mimo-detection.md
+++ b/_publications/2009-01-01-dual-lattice-algorithm-and-partial-lattice-reduction-for-sic-based-mimo-detection.md
@@ -1,0 +1,10 @@
+---
+title: "Dual-lattice algorithm and partial lattice reduction for SIC-based MIMO detection"
+collection: publications
+category: manuscripts
+permalink: /publication/dual-lattice-algorithm-and-partial-lattice-reduction-for-sic-based-mimo-detection
+date: 2009-01-01
+venue: 'IEEE J. Sel. Topics on Signal Processing'
+paperurl: ''
+citation: 'Cong Ling, Wai Ho Mow, and Lu Gan "<a href=''>Dual-lattice algorithm and partial lattice reduction for SIC-based MIMO detection</a>", IEEE J. Sel. Topics on Signal Processing, vol. 3, pp. 975-985, Dec. 2009.'
+---

--- a/_publications/2009-01-01-new-insights-into-weighted-bit-flipping-decoding-communications.md
+++ b/_publications/2009-01-01-new-insights-into-weighted-bit-flipping-decoding-communications.md
@@ -1,0 +1,10 @@
+---
+title: "New insights into weighted bit-flipping decoding Communications"
+collection: publications
+category: manuscripts
+permalink: /publication/new-insights-into-weighted-bit-flipping-decoding-communications
+date: 2009-01-01
+venue: 'IEEE Trans. Commun.'
+paperurl: ''
+citation: 'Xiaofu Wu, Cong Ling, Ming Jiang, Enyang Xu, Chunming Zhao, and Xiaohu You "<a href=''>New insights into weighted bit-flipping decoding Communications</a>", IEEE Trans. Commun., vol. 57, pp. 2177 – 2180, Aug. 2009.'
+---

--- a/_publications/2009-01-01-statistical-restricted-isometry-property-of-orthogonal-symmetric-toeplitz-matrices.md
+++ b/_publications/2009-01-01-statistical-restricted-isometry-property-of-orthogonal-symmetric-toeplitz-matrices.md
@@ -1,0 +1,10 @@
+---
+title: "Statistical restricted isometry property of orthogonal symmetric Toeplitz matrices"
+collection: publications
+category: conferences
+permalink: /publication/statistical-restricted-isometry-property-of-orthogonal-symmetric-toeplitz-matrices
+date: 2009-01-01
+venue: 'IEEE Inform. Theory Workshop 2009'
+paperurl: ''
+citation: 'Kezhi Li, Cong Ling and Lu Gan "<a href=''>Statistical restricted isometry property of orthogonal symmetric Toeplitz matrices</a>", IEEE Inform. Theory Workshop 2009, Taormina, Italy.'
+---

--- a/_publications/2010-01-01-effect-of-correlated-nakagami-m-fading-on-the-e-outage-channel-capacity-of-the-decentralized-two-relay-network.md
+++ b/_publications/2010-01-01-effect-of-correlated-nakagami-m-fading-on-the-e-outage-channel-capacity-of-the-decentralized-two-relay-network.md
@@ -1,0 +1,10 @@
+---
+title: "Effect of correlated Nakagami-m fading on the e-outage channel capacity of the decentralized two-relay network"
+collection: publications
+category: manuscripts
+permalink: /publication/effect-of-correlated-nakagami-m-fading-on-the-e-outage-channel-capacity-of-the-decentralized-two-relay-network
+date: 2010-01-01
+venue: 'IEEE Trans. Wireless. Commun.'
+paperurl: ''
+citation: 'Yifan Chen and Cong Ling "<a href=''>Effect of correlated Nakagami-m fading on the e-outage channel capacity of the decentralized two-relay network</a>", IEEE Trans. Wireless. Commun., vol. 9, pp. 3607-3612, Dec. 2010.'
+---

--- a/_publications/2010-01-01-randomized-lattice-decoding-bridging-the-gap-between-lattice-reduction-and-sphere-decoding.md
+++ b/_publications/2010-01-01-randomized-lattice-decoding-bridging-the-gap-between-lattice-reduction-and-sphere-decoding.md
@@ -1,0 +1,10 @@
+---
+title: "Randomized lattice decoding: Bridging the gap between lattice reduction and sphere decoding"
+collection: publications
+category: conferences
+permalink: /publication/randomized-lattice-decoding-bridging-the-gap-between-lattice-reduction-and-sphere-decoding
+date: 2010-01-01
+venue: 'IEEE Int. Symp. Inform. Theory’10'
+paperurl: ''
+citation: 'Shuiyin Liu, Cong Ling, and Damien Stehle "<a href=''>Randomized lattice decoding: Bridging the gap between lattice reduction and sphere decoding</a>", IEEE Int. Symp. Inform. Theory’10, Austin, US, June 2010.'
+---

--- a/_publications/2010-01-01-relay-aided-interference-alignment-feasibility-conditions-and-algorithm.md
+++ b/_publications/2010-01-01-relay-aided-interference-alignment-feasibility-conditions-and-algorithm.md
@@ -1,0 +1,10 @@
+---
+title: "Relay-aided interference alignment: Feasibility conditions and algorithm"
+collection: publications
+category: conferences
+permalink: /publication/relay-aided-interference-alignment-feasibility-conditions-and-algorithm
+date: 2010-01-01
+venue: 'IEEE Int. Symp. Inform. Theory’10'
+paperurl: ''
+citation: 'Hashi Ning, Cong Ling, and Kin K. Leung "<a href=''>Relay-aided interference alignment: Feasibility conditions and algorithm</a>", IEEE Int. Symp. Inform. Theory’10, Austin, US, June 2010.'
+---

--- a/_publications/2010-01-01-uwb-portable-printed-monopole-array-design-for-mimo-communications.md
+++ b/_publications/2010-01-01-uwb-portable-printed-monopole-array-design-for-mimo-communications.md
@@ -1,0 +1,10 @@
+---
+title: "UWB portable printed monopole array design for MIMO communications"
+collection: publications
+category: manuscripts
+permalink: /publication/uwb-portable-printed-monopole-array-design-for-mimo-communications
+date: 2010-01-01
+venue: 'Microwave and Optical Technology Letters'
+paperurl: ''
+citation: 'Daniel Valderas, Cong Ling, and Pedro Crespo "<a href=''>UWB portable printed monopole array design for MIMO communications</a>", Microwave and Optical Technology Letters, vol. 52, pp. 889-895, Apr. 2010.'
+---

--- a/_publications/2011-01-01-achievable-rates-for-lattice-coding-over-the-gaussian-wiretap-channel.md
+++ b/_publications/2011-01-01-achievable-rates-for-lattice-coding-over-the-gaussian-wiretap-channel.md
@@ -1,0 +1,10 @@
+---
+title: "Achievable rates for lattice coding over the Gaussian wiretap channel"
+collection: publications
+category: conferences
+permalink: /publication/achievable-rates-for-lattice-coding-over-the-gaussian-wiretap-channel
+date: 2011-01-01
+venue: 'ICC 2011 Physical Layer Security Workshop.'
+paperurl: ''
+citation: 'Li-Chia Choo, Cong Ling, and Kat-kit Wong "<a href=''>Achievable rates for lattice coding over the Gaussian wiretap channel</a>", ICC 2011 Physical Layer Security Workshop.'
+---

--- a/_publications/2011-01-01-decoding-by-sampling-a-randomized-lattice-algorithm-for-bounded-distance-decoding.md
+++ b/_publications/2011-01-01-decoding-by-sampling-a-randomized-lattice-algorithm-for-bounded-distance-decoding.md
@@ -1,0 +1,10 @@
+---
+title: "Decoding by sampling: A randomized lattice algorithm for bounded-distance decoding"
+collection: publications
+category: manuscripts
+permalink: /publication/decoding-by-sampling-a-randomized-lattice-algorithm-for-bounded-distance-decoding
+date: 2011-01-01
+venue: 'IEEE Trans. Inform. Theory'
+paperurl: 'http://arxiv.org/abs/1003.0064'
+citation: 'Shuiyin Liu, Cong Ling, and Damien Stehle "<a href='http://arxiv.org/abs/1003.0064'>Decoding by sampling: A randomized lattice algorithm for bounded-distance decoding</a>", IEEE Trans. Inform. Theory, vol. 57, pp. 5933-5945, Sept. 2011.'
+---

--- a/_publications/2011-01-01-deterministic-compressed-sensing-matrices-where-toeplitz-meets-golay.md
+++ b/_publications/2011-01-01-deterministic-compressed-sensing-matrices-where-toeplitz-meets-golay.md
@@ -1,0 +1,10 @@
+---
+title: "Deterministic compressed-sensing matrices: Where Toeplitz meets Golay"
+collection: publications
+category: manuscripts
+permalink: /publication/deterministic-compressed-sensing-matrices-where-toeplitz-meets-golay
+date: 2011-01-01
+venue: 'IEEE ICASSP 2011'
+paperurl: ''
+citation: 'Kezhi Li, Cong Ling and Lu Gan "<a href=''>Deterministic compressed-sensing matrices: Where Toeplitz meets Golay</a>", IEEE ICASSP 2011, Prague, Czech.'
+---

--- a/_publications/2011-01-01-feasibility-condition-for-interference-alignment-with-diversity.md
+++ b/_publications/2011-01-01-feasibility-condition-for-interference-alignment-with-diversity.md
@@ -1,0 +1,10 @@
+---
+title: "Feasibility condition for interference alignment with diversity"
+collection: publications
+category: manuscripts
+permalink: /publication/feasibility-condition-for-interference-alignment-with-diversity
+date: 2011-01-01
+venue: 'IEEE Trans. Inform. Theory'
+paperurl: ''
+citation: 'Haishi Ning, Cong Ling, and Kin. K. Leung "<a href=''>Feasibility condition for interference alignment with diversity</a>", IEEE Trans. Inform. Theory, vol. 57, pp. 2902-2912, May 2011.'
+---

--- a/_publications/2011-01-01-generalized-sequential-slotted-amplify-and-forward-strategy-in-cooperative-communications.md
+++ b/_publications/2011-01-01-generalized-sequential-slotted-amplify-and-forward-strategy-in-cooperative-communications.md
@@ -1,0 +1,10 @@
+---
+title: "Generalized sequential slotted amplify and forward strategy in cooperative communications"
+collection: publications
+category: manuscripts
+permalink: /publication/generalized-sequential-slotted-amplify-and-forward-strategy-in-cooperative-communications
+date: 2011-01-01
+venue: 'IEEE Trans. Inform. Theory'
+paperurl: ''
+citation: 'Haishi Ning, Cong Ling, and Kin. K. Leung "<a href=''>Generalized sequential slotted amplify and forward strategy in cooperative communications</a>", IEEE Trans. Inform. Theory, vol. 57, pp. 1968-1974, Apr. 2011.'
+---

--- a/_publications/2011-01-01-greedy-user-selection-using-a-lattice-reduction-updating-method-for-multiuser-mimo-systems.md
+++ b/_publications/2011-01-01-greedy-user-selection-using-a-lattice-reduction-updating-method-for-multiuser-mimo-systems.md
@@ -1,0 +1,10 @@
+---
+title: "Greedy user selection using a lattice reduction updating method for multiuser MIMO systems"
+collection: publications
+category: manuscripts
+permalink: /publication/greedy-user-selection-using-a-lattice-reduction-updating-method-for-multiuser-mimo-systems
+date: 2011-01-01
+venue: 'IEEE Trans. Vehicular Tech.'
+paperurl: ''
+citation: 'L. Bai, C. Chen, J. Choi, and C. Ling "<a href=''>Greedy user selection using a lattice reduction updating method for multiuser MIMO systems</a>", IEEE Trans. Vehicular Tech., vol. 60, pp. 136-147, Jan. 2011.'
+---

--- a/_publications/2011-01-01-on-the-proximity-factors-of-lattice-reduction-aided-decoding.md
+++ b/_publications/2011-01-01-on-the-proximity-factors-of-lattice-reduction-aided-decoding.md
@@ -1,0 +1,10 @@
+---
+title: "On the proximity factors of lattice reduction-aided decoding"
+collection: publications
+category: manuscripts
+permalink: /publication/on-the-proximity-factors-of-lattice-reduction-aided-decoding
+date: 2011-01-01
+venue: 'IEEE Trans. Signal Processing'
+paperurl: 'http://arxiv.org/abs/1006.1666'
+citation: 'Cong Ling "<a href='http://arxiv.org/abs/1006.1666'>On the proximity factors of lattice reduction-aided decoding</a>", IEEE Trans. Signal Processing, vol. 59, pp. 2795-2808, June 2011.'
+---

--- a/_publications/2011-01-01-secrecy-gain-of-trellis-codes-the-other-side-of-the-union-bound.md
+++ b/_publications/2011-01-01-secrecy-gain-of-trellis-codes-the-other-side-of-the-union-bound.md
@@ -1,0 +1,10 @@
+---
+title: "Secrecy gain of trellis codes: The other side of the union bound"
+collection: publications
+category: conferences
+permalink: /publication/secrecy-gain-of-trellis-codes-the-other-side-of-the-union-bound
+date: 2011-01-01
+venue: 'ITW 2011'
+paperurl: ''
+citation: 'Yanfei Yan, Cong Ling and Jean-Claude Belfiore "<a href=''>Secrecy gain of trellis codes: The other side of the union bound</a>", ITW 2011, Paraty, Brasil, Oct. 2011.'
+---

--- a/_publications/2012-01-01-a-construction-of-lattices-from-polar-codes.md
+++ b/_publications/2012-01-01-a-construction-of-lattices-from-polar-codes.md
@@ -1,0 +1,10 @@
+---
+title: "A construction of lattices from polar codes"
+collection: publications
+category: conferences
+permalink: /publication/a-construction-of-lattices-from-polar-codes
+date: 2012-01-01
+venue: 'IEEE Inform. Theory Workshop 2012.'
+paperurl: ''
+citation: 'Yanfei Yan and Cong Ling "<a href=''>A construction of lattices from polar codes</a>", IEEE Inform. Theory Workshop 2012.'
+---

--- a/_publications/2012-01-01-analysis-of-lattice-codes-for-the-many-to-one-interference-channel.md
+++ b/_publications/2012-01-01-analysis-of-lattice-codes-for-the-many-to-one-interference-channel.md
@@ -1,0 +1,10 @@
+---
+title: "Analysis of lattice codes for the many-to-one interference channel"
+collection: publications
+category: conferences
+permalink: /publication/analysis-of-lattice-codes-for-the-many-to-one-interference-channel
+date: 2012-01-01
+venue: 'IEEE Inform. Theory Workshop 2012.'
+paperurl: ''
+citation: 'Maria Estela, Laura Luzzi, Cong Ling and Jean-Claude Belfiore "<a href=''>Analysis of lattice codes for the many-to-one interference channel</a>", IEEE Inform. Theory Workshop 2012.'
+---

--- a/_publications/2012-01-01-derandomized-sampling-algorithm-for-lattice-decoding.md
+++ b/_publications/2012-01-01-derandomized-sampling-algorithm-for-lattice-decoding.md
@@ -1,0 +1,10 @@
+---
+title: "Derandomized sampling algorithm for lattice decoding"
+collection: publications
+category: conferences
+permalink: /publication/derandomized-sampling-algorithm-for-lattice-decoding
+date: 2012-01-01
+venue: 'IEEE Inform. Theory Workshop 2012.'
+paperurl: ''
+citation: 'Zheng Wang and Cong Ling "<a href=''>Derandomized sampling algorithm for lattice decoding</a>", IEEE Inform. Theory Workshop 2012.'
+---

--- a/_publications/2012-01-01-golay-meets-hadamard-golay-paired-hadamard-matrices-for-fast-compressed-sensing.md
+++ b/_publications/2012-01-01-golay-meets-hadamard-golay-paired-hadamard-matrices-for-fast-compressed-sensing.md
@@ -1,0 +1,10 @@
+---
+title: "Golay meets Hadamard: Golay-paired Hadamard matrices for fast compressed sensing"
+collection: publications
+category: conferences
+permalink: /publication/golay-meets-hadamard-golay-paired-hadamard-matrices-for-fast-compressed-sensing
+date: 2012-01-01
+venue: 'IEEE Inform. Theory Workshop 2012.'
+paperurl: ''
+citation: 'Lu Gan, Kezhi Li, and Cong Ling "<a href=''>Golay meets Hadamard: Golay-paired Hadamard matrices for fast compressed sensing</a>", IEEE Inform. Theory Workshop 2012.'
+---

--- a/_publications/2012-01-01-lattice-codes-achieving-strong-secrecy-over-the-mod-l-gaussian-channel.md
+++ b/_publications/2012-01-01-lattice-codes-achieving-strong-secrecy-over-the-mod-l-gaussian-channel.md
@@ -1,0 +1,10 @@
+---
+title: "Lattice codes achieving strong secrecy over the mod-L Gaussian channel"
+collection: publications
+category: conferences
+permalink: /publication/lattice-codes-achieving-strong-secrecy-over-the-mod-l-gaussian-channel
+date: 2012-01-01
+venue: 'ISIT 2012.'
+paperurl: ''
+citation: 'C. Ling, L. Luzzi, and J.-C. Belfiore "<a href=''>Lattice codes achieving strong secrecy over the mod-L Gaussian channel</a>", ISIT 2012.'
+---

--- a/_publications/2012-01-01-novel-toeptlitz-sensing-matrices-for-compressive-radar-imaging.md
+++ b/_publications/2012-01-01-novel-toeptlitz-sensing-matrices-for-compressive-radar-imaging.md
@@ -1,0 +1,10 @@
+---
+title: "Novel Toeptlitz sensing matrices for compressive radar imaging"
+collection: publications
+category: conferences
+permalink: /publication/novel-toeptlitz-sensing-matrices-for-compressive-radar-imaging
+date: 2012-01-01
+venue: '1st International Workshop on Compressed Sensing applied to Radar'
+paperurl: ''
+citation: 'Lu Gan, Kezhi Li, and Cong Ling "<a href=''>Novel Toeptlitz sensing matrices for compressive radar imaging</a>", 1st International Workshop on Compressed Sensing applied to Radar, 2012, Bonn, Germany.'
+---

--- a/_publications/2012-01-01-proximity-factors-of-lattice-reduction-aided-precoding-for-multiantenna-broadcast.md
+++ b/_publications/2012-01-01-proximity-factors-of-lattice-reduction-aided-precoding-for-multiantenna-broadcast.md
@@ -1,0 +1,10 @@
+---
+title: "Proximity factors of lattice reduction-aided precoding for multiantenna broadcast"
+collection: publications
+category: conferences
+permalink: /publication/proximity-factors-of-lattice-reduction-aided-precoding-for-multiantenna-broadcast
+date: 2012-01-01
+venue: 'ISIT 2012.'
+paperurl: ''
+citation: 'Suiyin Liu, Cong Ling and Xiaofu Wu "<a href=''>Proximity factors of lattice reduction-aided precoding for multiantenna broadcast</a>", ISIT 2012.'
+---

--- a/_publications/2012-01-01-reliable-sub-nyquist-wideband-spectrum-sensing-based-on-randomised-sampling.md
+++ b/_publications/2012-01-01-reliable-sub-nyquist-wideband-spectrum-sensing-based-on-randomised-sampling.md
@@ -1,0 +1,10 @@
+---
+title: "Reliable sub-Nyquist wideband spectrum sensing based on randomised sampling"
+collection: publications
+category: conferences
+permalink: /publication/reliable-sub-nyquist-wideband-spectrum-sensing-based-on-randomised-sampling
+date: 2012-01-01
+venue: '1st International Workshop on Compressed Sensing applied to Radar'
+paperurl: ''
+citation: 'B. Ahmad, W. Dai, and C. Ling "<a href=''>Reliable sub-Nyquist wideband spectrum sensing based on randomised sampling</a>", 1st International Workshop on Compressed Sensing applied to Radar, 2012, Bonn, Germany.'
+---

--- a/_publications/2012-01-01-the-flatness-factor-in-lattice-network-coding-design-criterion-and-decoding-algorithm.md
+++ b/_publications/2012-01-01-the-flatness-factor-in-lattice-network-coding-design-criterion-and-decoding-algorithm.md
@@ -1,0 +1,10 @@
+---
+title: "The flatness factor in lattice network coding: Design criterion and decoding algorithm"
+collection: publications
+category: conferences
+permalink: /publication/the-flatness-factor-in-lattice-network-coding-design-criterion-and-decoding-algorithm
+date: 2012-01-01
+venue: 'International Zurich Seminar on Communications 2012'
+paperurl: ''
+citation: 'J.-C. Belfiore and Cong Ling "<a href=''>The flatness factor in lattice network coding: Design criterion and decoding algorithm</a>", International Zurich Seminar on Communications 2012, invited paper.'
+---

--- a/_publications/2012-01-01-wyner-ziv-coding-based-on-multi-dimensional-nested-lattices.md
+++ b/_publications/2012-01-01-wyner-ziv-coding-based-on-multi-dimensional-nested-lattices.md
@@ -1,0 +1,10 @@
+---
+title: "Wyner-Ziv coding based on multi-dimensional nested lattices"
+collection: publications
+category: manuscripts
+permalink: /publication/wyner-ziv-coding-based-on-multi-dimensional-nested-lattices
+date: 2012-01-01
+venue: 'IEEE Trans. Commun.'
+paperurl: 'http://arxiv.org/abs/1111.1347'
+citation: 'Cong Ling, Su Gao, and Jean-Claude Belfiore "<a href='http://arxiv.org/abs/1111.1347'>Wyner-Ziv coding based on multi-dimensional nested lattices</a>", IEEE Trans. Commun., vol. 60, pp.1328-1335, May 2012.'
+---

--- a/_publications/2013-01-01-achieving-the-awgn-channel-capacity-with-lattice-gaussian-distribution.md
+++ b/_publications/2013-01-01-achieving-the-awgn-channel-capacity-with-lattice-gaussian-distribution.md
@@ -1,0 +1,10 @@
+---
+title: "Achieving the AWGN channel capacity with lattice Gaussian distribution"
+collection: publications
+category: conferences
+permalink: /publication/achieving-the-awgn-channel-capacity-with-lattice-gaussian-distribution
+date: 2013-01-01
+venue: 'ISIT 2013.'
+paperurl: ''
+citation: 'Cong Ling and Jean-Claude Belfiore "<a href=''>Achieving the AWGN channel capacity with lattice Gaussian distribution</a>", ISIT 2013.'
+---

--- a/_publications/2013-01-01-barnes-wall-lattices-for-symmetric-interference-channel.md
+++ b/_publications/2013-01-01-barnes-wall-lattices-for-symmetric-interference-channel.md
@@ -1,0 +1,10 @@
+---
+title: "Barnes-Wall lattices for symmetric interference channel"
+collection: publications
+category: conferences
+permalink: /publication/barnes-wall-lattices-for-symmetric-interference-channel
+date: 2013-01-01
+venue: 'ISIT 2013.'
+paperurl: ''
+citation: 'Maria Estela, Cong Ling and Jean-Claude Belfiore "<a href=''>Barnes-Wall lattices for symmetric interference channel</a>", ISIT 2013.'
+---

--- a/_publications/2013-01-01-convolutional-compressed-sensing-using-deterministic-sequences.md
+++ b/_publications/2013-01-01-convolutional-compressed-sensing-using-deterministic-sequences.md
@@ -1,0 +1,10 @@
+---
+title: "Convolutional compressed sensing using deterministic sequences"
+collection: publications
+category: manuscripts
+permalink: /publication/convolutional-compressed-sensing-using-deterministic-sequences
+date: 2013-01-01
+venue: 'IEEE Trans. Signal Processing'
+paperurl: 'http://arxiv.org/abs/1210.7506'
+citation: 'Kezhi Li, Lu Gan, and Cong Ling "<a href='http://arxiv.org/abs/1210.7506'>Convolutional compressed sensing using deterministic sequences</a>", IEEE Trans. Signal Processing, vol. 61, pp. 740-752, Feb. 2013.'
+---

--- a/_publications/2013-01-01-decoding-by-embedding-correct-decoding-radius-and-dmt-optimality.md
+++ b/_publications/2013-01-01-decoding-by-embedding-correct-decoding-radius-and-dmt-optimality.md
@@ -1,0 +1,10 @@
+---
+title: "Decoding by embedding: Correct decoding radius and DMT optimality"
+collection: publications
+category: manuscripts
+permalink: /publication/decoding-by-embedding-correct-decoding-radius-and-dmt-optimality
+date: 2013-01-01
+venue: 'IEEE Trans. Inform. Theory'
+paperurl: 'http://arxiv.org/abs/1102.2936'
+citation: 'Laura Luzzi, Damien Stehle, and Cong Ling "<a href='http://arxiv.org/abs/1102.2936'>Decoding by embedding: Correct decoding radius and DMT optimality</a>", IEEE Trans. Inform. Theory, vol. 59, pp. 1960-2973, May 2013.'
+---

--- a/_publications/2013-01-01-decoding-by-sampling-part-ii-derandomization-and-soft-output-decoding.md
+++ b/_publications/2013-01-01-decoding-by-sampling-part-ii-derandomization-and-soft-output-decoding.md
@@ -1,0 +1,10 @@
+---
+title: "Decoding by sampling-Part II: Derandomization and soft-output decoding"
+collection: publications
+category: manuscripts
+permalink: /publication/decoding-by-sampling-part-ii-derandomization-and-soft-output-decoding
+date: 2013-01-01
+venue: 'IEEE Trans. Commun.'
+paperurl: 'http://arxiv.org/abs/1305.5762'
+citation: 'Zheng Wang, Shuiyin Liu and Cong Ling "<a href='http://arxiv.org/abs/1305.5762'>Decoding by sampling-Part II: Derandomization and soft-output decoding</a>", IEEE Trans. Commun., vol. 61, no. 11, pp. 4630 – 4639, Nov. 2013.'
+---

--- a/_publications/2013-01-01-deterministic-sequences-for-compressive-mimo-channel-estimation.md
+++ b/_publications/2013-01-01-deterministic-sequences-for-compressive-mimo-channel-estimation.md
@@ -1,0 +1,10 @@
+---
+title: "Deterministic sequences for compressive MIMO channel estimation"
+collection: publications
+category: manuscripts
+permalink: /publication/deterministic-sequences-for-compressive-mimo-channel-estimation
+date: 2013-01-01
+venue: 'EUSIPCO 2013.'
+paperurl: ''
+citation: 'Peng Zhang, Lu Gan, Sumei Sun and Cong Ling "<a href=''>Deterministic sequences for compressive MIMO channel estimation</a>", EUSIPCO 2013.'
+---

--- a/_publications/2013-01-01-integration-of-gps-with-a-wifi-high-accuracy-ranging-functionality.md
+++ b/_publications/2013-01-01-integration-of-gps-with-a-wifi-high-accuracy-ranging-functionality.md
@@ -1,0 +1,10 @@
+---
+title: "Integration of GPS with a WiFi high accuracy ranging functionality"
+collection: publications
+category: manuscripts
+permalink: /publication/integration-of-gps-with-a-wifi-high-accuracy-ranging-functionality
+date: 2013-01-01
+venue: 'Geo-spatial Information Science'
+paperurl: ''
+citation: 'K Nur, S. Fenga, C. Ling and W. Ochieng "<a href=''>Integration of GPS with a WiFi high accuracy ranging functionality</a>", Geo-spatial Information Science, vol. 16, no. 3, pp. 155-168, 2013.'
+---

--- a/_publications/2013-01-01-lattice-quantization-noise-revisited.md
+++ b/_publications/2013-01-01-lattice-quantization-noise-revisited.md
@@ -1,0 +1,10 @@
+---
+title: "Lattice quantization noise revisited"
+collection: publications
+category: conferences
+permalink: /publication/lattice-quantization-noise-revisited
+date: 2013-01-01
+venue: 'IEEE Inform. Theory Workshop 2013.'
+paperurl: ''
+citation: 'Cong Ling and Lu Gan "<a href=''>Lattice quantization noise revisited</a>", IEEE Inform. Theory Workshop 2013.'
+---

--- a/_publications/2013-01-01-polar-lattices-where-arikan-meets-forney.md
+++ b/_publications/2013-01-01-polar-lattices-where-arikan-meets-forney.md
@@ -1,0 +1,10 @@
+---
+title: "Polar lattices: Where Arikan meets Forney"
+collection: publications
+category: conferences
+permalink: /publication/polar-lattices-where-arikan-meets-forney
+date: 2013-01-01
+venue: 'ISIT 2013.'
+paperurl: ''
+citation: 'Yanfei Yan, Cong Ling and Xiaofu Wu "<a href=''>Polar lattices: Where Arikan meets Forney</a>", ISIT 2013.'
+---

--- a/_publications/2013-01-01-reduced-and-fixed-complexity-variants-of-the-lll-algorithm-for-communications.md
+++ b/_publications/2013-01-01-reduced-and-fixed-complexity-variants-of-the-lll-algorithm-for-communications.md
@@ -1,0 +1,10 @@
+---
+title: "Reduced and fixed-complexity variants of the LLL algorithm for communications"
+collection: publications
+category: manuscripts
+permalink: /publication/reduced-and-fixed-complexity-variants-of-the-lll-algorithm-for-communications
+date: 2013-01-01
+venue: 'IEEE Trans. Commun.'
+paperurl: 'http://arxiv.org/abs/1006.1661'
+citation: 'Cong Ling, Wai Ho Mow, and Nick Howgrave-Graham "<a href='http://arxiv.org/abs/1006.1661'>Reduced and fixed-complexity variants of the LLL algorithm for communications</a>", IEEE Trans. Commun., vol. 61, pp. 1040-1050, Mar. 2013.'
+---

--- a/_publications/2013-01-01-secret-key-generation-from-gaussian-sources-using-lattice-hashing.md
+++ b/_publications/2013-01-01-secret-key-generation-from-gaussian-sources-using-lattice-hashing.md
@@ -1,0 +1,10 @@
+---
+title: "Secret key generation from Gaussian sources using lattice hashing"
+collection: publications
+category: conferences
+permalink: /publication/secret-key-generation-from-gaussian-sources-using-lattice-hashing
+date: 2013-01-01
+venue: 'ISIT 2013.'
+paperurl: ''
+citation: 'Cong Ling, Laura Luzzi and Matthieu Bloch "<a href=''>Secret key generation from Gaussian sources using lattice hashing</a>", ISIT 2013.'
+---

--- a/_publications/2014-01-01-achievable-diversity-rate-tradeoff-of-mimo-af-relaying-systems-with-mmse-transceivers.md
+++ b/_publications/2014-01-01-achievable-diversity-rate-tradeoff-of-mimo-af-relaying-systems-with-mmse-transceivers.md
@@ -1,0 +1,10 @@
+---
+title: "Achievable Diversity-Rate Tradeoff of MIMO AF Relaying Systems with MMSE Transceivers"
+collection: publications
+category: conferences
+permalink: /publication/achievable-diversity-rate-tradeoff-of-mimo-af-relaying-systems-with-mmse-transceivers
+date: 2014-01-01
+venue: 'ISIT 2014.'
+paperurl: ''
+citation: 'Changick Song and Cong Ling "<a href=''>Achievable Diversity-Rate Tradeoff of MIMO AF Relaying Systems with MMSE Transceivers</a>", ISIT 2014.'
+---

--- a/_publications/2014-01-01-achieving-awgn-channel-capacity-with-lattice-gaussian-coding.md
+++ b/_publications/2014-01-01-achieving-awgn-channel-capacity-with-lattice-gaussian-coding.md
@@ -1,0 +1,10 @@
+---
+title: "Achieving AWGN channel capacity with lattice Gaussian coding"
+collection: publications
+category: manuscripts
+permalink: /publication/achieving-awgn-channel-capacity-with-lattice-gaussian-coding
+date: 2014-01-01
+venue: 'IEEE Trans. Inform. Theory'
+paperurl: 'http://arxiv.org/abs/1302.5906'
+citation: 'Cong Ling and Jean-Claude Belfiore "<a href='http://arxiv.org/abs/1302.5906'>Achieving AWGN channel capacity with lattice Gaussian coding</a>", IEEE Trans. Inform. Theory, vol. 60, no. 10, pp. 5918–5929, Oct. 2014.'
+---

--- a/_publications/2014-01-01-lattice-gaussian-coding-for-capacity-and-secrecy-two-sides-of-one-coin.md
+++ b/_publications/2014-01-01-lattice-gaussian-coding-for-capacity-and-secrecy-two-sides-of-one-coin.md
@@ -1,0 +1,10 @@
+---
+title: "Lattice Gaussian Coding for Capacity and Secrecy: Two Sides of One Coin"
+collection: publications
+category: conferences
+permalink: /publication/lattice-gaussian-coding-for-capacity-and-secrecy-two-sides-of-one-coin
+date: 2014-01-01
+venue: 'International Zurich Seminar on Communications 2014 (invited paper).'
+paperurl: ''
+citation: 'Cong Ling and Jean-Claude Belfiore "<a href=''>Lattice Gaussian Coding for Capacity and Secrecy: Two Sides of One Coin</a>", International Zurich Seminar on Communications 2014 (invited paper).'
+---

--- a/_publications/2014-01-01-markov-chain-monte-carlo-algorithms-for-lattice-gaussian-sampling.md
+++ b/_publications/2014-01-01-markov-chain-monte-carlo-algorithms-for-lattice-gaussian-sampling.md
@@ -1,0 +1,10 @@
+---
+title: "Markov Chain Monte Carlo Algorithms for Lattice Gaussian Sampling"
+collection: publications
+category: conferences
+permalink: /publication/markov-chain-monte-carlo-algorithms-for-lattice-gaussian-sampling
+date: 2014-01-01
+venue: 'ISIT 2014.'
+paperurl: ''
+citation: 'Zheng Wang, Cong Ling, and Guillaume Hanrot "<a href=''>Markov Chain Monte Carlo Algorithms for Lattice Gaussian Sampling</a>", ISIT 2014.'
+---

--- a/_publications/2014-01-01-mimo-broadcasting-for-simultaneous-wireless-information-and-power-transfer-weighted-mmse-approaches.md
+++ b/_publications/2014-01-01-mimo-broadcasting-for-simultaneous-wireless-information-and-power-transfer-weighted-mmse-approaches.md
@@ -1,0 +1,10 @@
+---
+title: "MIMO Broadcasting for Simultaneous Wireless Information and Power Transfer: Weighted MMSE Approaches"
+collection: publications
+category: manuscripts
+permalink: /publication/mimo-broadcasting-for-simultaneous-wireless-information-and-power-transfer-weighted-mmse-approaches
+date: 2014-01-01
+venue: 'Globecom 2014.'
+paperurl: 'http://arxiv.org/abs/1410.4360'
+citation: 'Changick Song, Cong Ling, Jaehyun Park, Bruno Clerckx "<a href='http://arxiv.org/abs/1410.4360'>MIMO Broadcasting for Simultaneous Wireless Information and Power Transfer: Weighted MMSE Approaches</a>", Globecom 2014.'
+---

--- a/_publications/2014-01-01-polar-lattices-for-strong-secrecy-over-the-mod-lambda-gaussian-wiretap-channel.md
+++ b/_publications/2014-01-01-polar-lattices-for-strong-secrecy-over-the-mod-lambda-gaussian-wiretap-channel.md
@@ -1,0 +1,10 @@
+---
+title: "Polar Lattices for Strong Secrecy Over the Mod-Lambda Gaussian Wiretap Channel"
+collection: publications
+category: conferences
+permalink: /publication/polar-lattices-for-strong-secrecy-over-the-mod-lambda-gaussian-wiretap-channel
+date: 2014-01-01
+venue: 'ISIT 2014.'
+paperurl: ''
+citation: 'Yanfei Yan, Ling Liu and Cong Ling "<a href=''>Polar Lattices for Strong Secrecy Over the Mod-Lambda Gaussian Wiretap Channel</a>", ISIT 2014.'
+---

--- a/_publications/2014-01-01-secrecy-gain-flatness-factor-and-secrecy-goodness-of-even-unimodular-lattices.md
+++ b/_publications/2014-01-01-secrecy-gain-flatness-factor-and-secrecy-goodness-of-even-unimodular-lattices.md
@@ -1,0 +1,10 @@
+---
+title: "Secrecy gain, flatness factor, and secrecy-goodness of even unimodular lattices"
+collection: publications
+category: conferences
+permalink: /publication/secrecy-gain-flatness-factor-and-secrecy-goodness-of-even-unimodular-lattices
+date: 2014-01-01
+venue: 'ISIT 2014.'
+paperurl: ''
+citation: 'Fuchun Lin, Cong Ling, and Jean-Claude Belfiore "<a href=''>Secrecy gain, flatness factor, and secrecy-goodness of even unimodular lattices</a>", ISIT 2014.'
+---

--- a/_publications/2014-01-01-semantically-secure-lattice-codes-for-the-gaussian-wiretap-channel.md
+++ b/_publications/2014-01-01-semantically-secure-lattice-codes-for-the-gaussian-wiretap-channel.md
@@ -1,0 +1,10 @@
+---
+title: "Semantically secure lattice codes for the Gaussian wiretap channel"
+collection: publications
+category: manuscripts
+permalink: /publication/semantically-secure-lattice-codes-for-the-gaussian-wiretap-channel
+date: 2014-01-01
+venue: 'IEEE Trans. Inform. Theory'
+paperurl: 'http://arxiv.org/abs/1210.6673'
+citation: 'Cong Ling, Laura Luzzi, Jean-Claude Belfiore, and Damien Stehle "<a href='http://arxiv.org/abs/1210.6673'>Semantically secure lattice codes for the Gaussian wiretap channel</a>", IEEE Trans. Inform. Theory, vol. 60, no. 10, pp. 6399–6416, Oct. 2014.'
+---

--- a/_publications/2014-01-01-superposition-lattice-coding-for-gaussian-broadcast-channel-with-confidential-message.md
+++ b/_publications/2014-01-01-superposition-lattice-coding-for-gaussian-broadcast-channel-with-confidential-message.md
@@ -1,0 +1,10 @@
+---
+title: "Superposition Lattice Coding for Gaussian Broadcast Channel with Confidential Message"
+collection: publications
+category: conferences
+permalink: /publication/superposition-lattice-coding-for-gaussian-broadcast-channel-with-confidential-message
+date: 2014-01-01
+venue: 'IEEE Inform. Theory Workshop 2014 (invited paper).'
+paperurl: ''
+citation: 'Li Chia Choo and Cong Ling "<a href=''>Superposition Lattice Coding for Gaussian Broadcast Channel with Confidential Message</a>", IEEE Inform. Theory Workshop 2014 (invited paper).'
+---

--- a/_publications/2014-01-01-variable-density-sampling-on-the-dual-lattice.md
+++ b/_publications/2014-01-01-variable-density-sampling-on-the-dual-lattice.md
@@ -1,0 +1,10 @@
+---
+title: "Variable-Density Sampling on the Dual Lattice"
+collection: publications
+category: conferences
+permalink: /publication/variable-density-sampling-on-the-dual-lattice
+date: 2014-01-01
+venue: 'ISIT 2014.'
+paperurl: ''
+citation: 'Peng Zhang, Sumei Sun, and Cong Ling "<a href=''>Variable-Density Sampling on the Dual Lattice</a>", ISIT 2014.'
+---

--- a/_publications/2015-01-01-atomic-norm-denoising-based-channel-estimation-for-massive-multiuser-mimo-systems.md
+++ b/_publications/2015-01-01-atomic-norm-denoising-based-channel-estimation-for-massive-multiuser-mimo-systems.md
@@ -1,0 +1,10 @@
+---
+title: "Atomic Norm Denoising-based Channel Estimation for Massive Multiuser MIMO Systems"
+collection: publications
+category: conferences
+permalink: /publication/atomic-norm-denoising-based-channel-estimation-for-massive-multiuser-mimo-systems
+date: 2015-01-01
+venue: 'ICC 2015.'
+paperurl: ''
+citation: 'Peng Zhang, Lu Gan, Sumei Sun, and Cong Ling "<a href=''>Atomic Norm Denoising-based Channel Estimation for Massive Multiuser MIMO Systems</a>", ICC 2015.'
+---

--- a/_publications/2015-01-01-independent-metropolis-hastings-klein-algorithm-for-lattice-gaussian-sampling.md
+++ b/_publications/2015-01-01-independent-metropolis-hastings-klein-algorithm-for-lattice-gaussian-sampling.md
@@ -1,0 +1,10 @@
+---
+title: "Independent Metropolis-Hastings-Klein Algorithm for Lattice Gaussian Sampling"
+collection: publications
+category: conferences
+permalink: /publication/independent-metropolis-hastings-klein-algorithm-for-lattice-gaussian-sampling
+date: 2015-01-01
+venue: 'ISIT 2015.'
+paperurl: 'http://arxiv.org/abs/1501.05757'
+citation: 'Zheng Wang and Cong Ling "<a href='http://arxiv.org/abs/1501.05757'>Independent Metropolis-Hastings-Klein Algorithm for Lattice Gaussian Sampling</a>", ISIT 2015.'
+---

--- a/_publications/2015-01-01-modulated-unit-norm-tight-frames-for-compressed-sensing.md
+++ b/_publications/2015-01-01-modulated-unit-norm-tight-frames-for-compressed-sensing.md
@@ -1,0 +1,10 @@
+---
+title: "Modulated Unit-Norm Tight Frames for Compressed Sensing"
+collection: publications
+category: manuscripts
+permalink: /publication/modulated-unit-norm-tight-frames-for-compressed-sensing
+date: 2015-01-01
+venue: 'IEEE Trans. Signal Processing'
+paperurl: 'http://arxiv.org/abs/1411.7630'
+citation: 'Peng Zhang, Lu Gan, Sumei Sun, and Cong Ling "<a href='http://arxiv.org/abs/1411.7630'>Modulated Unit-Norm Tight Frames for Compressed Sensing</a>", IEEE Trans. Signal Processing, vol. 63, no. 15, pp. 3974–3985, August 2015.'
+---

--- a/_publications/2015-01-01-nested-array-with-time-delayers-for-target-range-and-angle-estimation.md
+++ b/_publications/2015-01-01-nested-array-with-time-delayers-for-target-range-and-angle-estimation.md
@@ -1,0 +1,10 @@
+---
+title: "Nested Array With Time-Delayers for Target Range and Angle Estimation"
+collection: publications
+category: conferences
+permalink: /publication/nested-array-with-time-delayers-for-target-range-and-angle-estimation
+date: 2015-01-01
+venue: '3rd International Workshop on Compressed Sensing Theory and its Applications to Radar'
+paperurl: ''
+citation: 'Wen-Qin Wang and Cong Ling "<a href=''>Nested Array With Time-Delayers for Target Range and Angle Estimation</a>", 3rd International Workshop on Compressed Sensing Theory and its Applications to Radar, Sonar, and Remote Sensing (CoSeRa) 2015.'
+---

--- a/_publications/2016-01-01-achieving-capacity-and-security-in-wireless-communications-with-lattice-codes.md
+++ b/_publications/2016-01-01-achieving-capacity-and-security-in-wireless-communications-with-lattice-codes.md
@@ -1,0 +1,10 @@
+---
+title: "Achieving Capacity and Security in Wireless Communications With Lattice Codes"
+collection: publications
+category: conferences
+permalink: /publication/achieving-capacity-and-security-in-wireless-communications-with-lattice-codes
+date: 2016-01-01
+venue: 'International Symposium on Turbo Codes 2016.'
+paperurl: ''
+citation: 'Cong Ling "<a href=''>Achieving Capacity and Security in Wireless Communications With Lattice Codes</a>",  International Symposium on Turbo Codes 2016.'
+---

--- a/_publications/2016-01-01-algebraic-lattice-codes-achieve-the-capacity-of-the-compound-block-fading-channel.md
+++ b/_publications/2016-01-01-algebraic-lattice-codes-achieve-the-capacity-of-the-compound-block-fading-channel.md
@@ -1,0 +1,10 @@
+---
+title: "Algebraic Lattice Codes Achieve the Capacity of the Compound Block-Fading Channel"
+collection: publications
+category: conferences
+permalink: /publication/algebraic-lattice-codes-achieve-the-capacity-of-the-compound-block-fading-channel
+date: 2016-01-01
+venue: 'ISIT 2016.'
+paperurl: 'http://arxiv.org/abs/1603.09263'
+citation: 'Antonio Campello, Cong Ling and Jean-Claude Belfiore "<a href='http://arxiv.org/abs/1603.09263'>Algebraic Lattice Codes Achieve the Capacity of the Compound Block-Fading Channel</a>", ISIT 2016.'
+---

--- a/_publications/2016-01-01-algebraic-lattices-achieve-the-capacity-of-the-ergodic-fading-channel.md
+++ b/_publications/2016-01-01-algebraic-lattices-achieve-the-capacity-of-the-ergodic-fading-channel.md
@@ -1,0 +1,10 @@
+---
+title: "Algebraic lattices achieve the capacity of the ergodic fading channel"
+collection: publications
+category: conferences
+permalink: /publication/algebraic-lattices-achieve-the-capacity-of-the-ergodic-fading-channel
+date: 2016-01-01
+venue: 'ITW 2016.'
+paperurl: ''
+citation: 'Antonio Campello, Cong Ling and Jean-Claude Belfiore "<a href=''>Algebraic lattices achieve the capacity of the ergodic fading channel</a>", ITW 2016.'
+---

--- a/_publications/2016-01-01-almost-universal-codes-for-fading-wiretap-channels.md
+++ b/_publications/2016-01-01-almost-universal-codes-for-fading-wiretap-channels.md
@@ -1,0 +1,10 @@
+---
+title: "Almost universal codes for fading wiretap channels"
+collection: publications
+category: conferences
+permalink: /publication/almost-universal-codes-for-fading-wiretap-channels
+date: 2016-01-01
+venue: 'ISIT 2016.'
+paperurl: 'http://arxiv.org/abs/1601.02391'
+citation: 'L. Luzzi, C. Ling and R. Vehkalahti "<a href='http://arxiv.org/abs/1601.02391'>Almost universal codes for fading wiretap channels</a>", ISIT 2016.'
+---

--- a/_publications/2016-01-01-artificial-noise-aided-message-authentication-codes-with-information-theoretic-security.md
+++ b/_publications/2016-01-01-artificial-noise-aided-message-authentication-codes-with-information-theoretic-security.md
@@ -1,0 +1,10 @@
+---
+title: "Artificial-Noise-Aided Message Authentication Codes with Information-Theoretic Security"
+collection: publications
+category: manuscripts
+permalink: /publication/artificial-noise-aided-message-authentication-codes-with-information-theoretic-security
+date: 2016-01-01
+venue: 'IEEE Trans. Inform. Forensics & Security'
+paperurl: 'http://arxiv.org/abs/1511.05357'
+citation: 'Xiaofu Wu, Zhen Yang, Cong Ling, Xiang-Gen Xia "<a href='http://arxiv.org/abs/1511.05357'>Artificial-Noise-Aided Message Authentication Codes with Information-Theoretic Security</a>", IEEE Trans. Inform. Forensics & Security, vol. 11, no. 6, pp. 1278–1290, Jan. 2016.'
+---

--- a/_publications/2016-01-01-artificial-noise-aided-physical-layer-phase-challenge-response-authentication-for-practical-ofdm-transmission.md
+++ b/_publications/2016-01-01-artificial-noise-aided-physical-layer-phase-challenge-response-authentication-for-practical-ofdm-transmission.md
@@ -1,0 +1,10 @@
+---
+title: "Artificial-Noise-Aided Physical Layer Phase Challenge-Response Authentication for Practical OFDM Transmission"
+collection: publications
+category: manuscripts
+permalink: /publication/artificial-noise-aided-physical-layer-phase-challenge-response-authentication-for-practical-ofdm-transmission
+date: 2016-01-01
+venue: 'IEEE Trans. Wireless Commun.'
+paperurl: 'http://arxiv.org/abs/1502.07565'
+citation: 'Xiaofu Wu, Zhen Yan, Cong Ling, Xiang-Gen Xia "<a href='http://arxiv.org/abs/1502.07565'>Artificial-Noise-Aided Physical Layer Phase Challenge-Response Authentication for Practical OFDM Transmission</a>", IEEE Trans. Wireless Commun., vol. 15, pp. 6611-6625, Oct. 2016.'
+---

--- a/_publications/2016-01-01-efficient-integer-coefficient-search-for-compute-and-forward.md
+++ b/_publications/2016-01-01-efficient-integer-coefficient-search-for-compute-and-forward.md
@@ -1,0 +1,10 @@
+---
+title: "Efficient Integer Coefficient Search for Compute-and-Forward"
+collection: publications
+category: manuscripts
+permalink: /publication/efficient-integer-coefficient-search-for-compute-and-forward
+date: 2016-01-01
+venue: 'IEEE Trans. Wireless Commun.'
+paperurl: 'https://arxiv.org/abs/1609.05490'
+citation: 'William Liu and Cong Ling "<a href='https://arxiv.org/abs/1609.05490'>Efficient Integer Coefficient Search for Compute-and-Forward</a>", IEEE Trans. Wireless Commun., vol. 15, pp. 8039-8050, Dec. 2016.'
+---

--- a/_publications/2016-01-01-further-results-on-independent-metropolis-hastings-klein-sampling.md
+++ b/_publications/2016-01-01-further-results-on-independent-metropolis-hastings-klein-sampling.md
@@ -1,0 +1,10 @@
+---
+title: "Further Results on Independent Metropolis-Hastings-Klein Sampling"
+collection: publications
+category: conferences
+permalink: /publication/further-results-on-independent-metropolis-hastings-klein-sampling
+date: 2016-01-01
+venue: 'ISIT 2016.'
+paperurl: ''
+citation: 'Zheng Wang and Cong Ling "<a href=''>Further Results on Independent Metropolis-Hastings-Klein Sampling</a>", ISIT 2016.'
+---

--- a/_publications/2016-01-01-on-the-diversity-of-linear-transceivers-in-mimo-af-relaying-systems.md
+++ b/_publications/2016-01-01-on-the-diversity-of-linear-transceivers-in-mimo-af-relaying-systems.md
@@ -1,0 +1,10 @@
+---
+title: "On the Diversity of Linear Transceivers in MIMO AF Relaying Systems"
+collection: publications
+category: manuscripts
+permalink: /publication/on-the-diversity-of-linear-transceivers-in-mimo-af-relaying-systems
+date: 2016-01-01
+venue: 'IEEE Trans. Inform. Theory'
+paperurl: 'http://arxiv.org/abs/1403.2081'
+citation: 'Changick Song and Cong Ling "<a href='http://arxiv.org/abs/1403.2081'>On the Diversity of Linear Transceivers in MIMO AF Relaying Systems</a>",  IEEE Trans. Inform. Theory, vol. 62, no. 1, pp. 272–289, Jan. 2016.'
+---

--- a/_publications/2016-01-01-polar-codes-and-polar-lattices-for-independent-fading-channels.md
+++ b/_publications/2016-01-01-polar-codes-and-polar-lattices-for-independent-fading-channels.md
@@ -1,0 +1,10 @@
+---
+title: "Polar Codes and Polar Lattices for Independent Fading Channels"
+collection: publications
+category: manuscripts
+permalink: /publication/polar-codes-and-polar-lattices-for-independent-fading-channels
+date: 2016-01-01
+venue: 'IEEE Trans. Commun.'
+paperurl: 'https://arxiv.org/abs/1601.04967'
+citation: 'Ling Liu and Cong Ling "<a href='https://arxiv.org/abs/1601.04967'>Polar Codes and Polar Lattices for Independent Fading Channels</a>", IEEE Trans. Commun., vol. 64, pp. 4923-4935, Dec. 2016.'
+---

--- a/_publications/2016-01-01-symmetric-mettropolis-within-gibbs-algorithm-for-lattice-gaussian-sampling.md
+++ b/_publications/2016-01-01-symmetric-mettropolis-within-gibbs-algorithm-for-lattice-gaussian-sampling.md
@@ -1,0 +1,10 @@
+---
+title: "Symmetric Mettropolis-within-Gibbs Algorithm for Lattice Gaussian Sampling"
+collection: publications
+category: conferences
+permalink: /publication/symmetric-mettropolis-within-gibbs-algorithm-for-lattice-gaussian-sampling
+date: 2016-01-01
+venue: 'ITW 2016.'
+paperurl: ''
+citation: 'Zheng Wang and Cong Ling "<a href=''>Symmetric Mettropolis-within-Gibbs Algorithm for Lattice Gaussian Sampling</a>",  ITW 2016.'
+---

--- a/_publications/2017-01-01-compute-and-forward-over-block-fading-channels-using-algebraic-lattices.md
+++ b/_publications/2017-01-01-compute-and-forward-over-block-fading-channels-using-algebraic-lattices.md
@@ -1,0 +1,10 @@
+---
+title: "Compute-and-Forward over Block-Fading Channels Using Algebraic Lattices"
+collection: publications
+category: conferences
+permalink: /publication/compute-and-forward-over-block-fading-channels-using-algebraic-lattices
+date: 2017-01-01
+venue: 'ISIT 2017.'
+paperurl: 'https://arxiv.org/abs/1702.01422'
+citation: 'Shanxiang Lyu, Antonio Campello, Cong Ling and Jean-Claude Belfiore "<a href='https://arxiv.org/abs/1702.01422'>Compute-and-Forward over Block-Fading Channels Using Algebraic Lattices</a>", ISIT 2017.'
+---

--- a/_publications/2017-01-01-coprime-sensing-by-chinese-remaindering-over-rings.md
+++ b/_publications/2017-01-01-coprime-sensing-by-chinese-remaindering-over-rings.md
@@ -1,0 +1,10 @@
+---
+title: "Coprime Sensing by Chinese Remaindering over Rings"
+collection: publications
+category: manuscripts
+permalink: /publication/coprime-sensing-by-chinese-remaindering-over-rings
+date: 2017-01-01
+venue: 'SAMPTA 2017.'
+paperurl: ''
+citation: 'Conghui Li, Lu Gan and Cong Ling "<a href=''>Coprime Sensing by Chinese Remaindering over Rings</a>", SAMPTA 2017.'
+---

--- a/_publications/2017-01-01-multilevel-code-construction-for-compound-fading-channels.md
+++ b/_publications/2017-01-01-multilevel-code-construction-for-compound-fading-channels.md
@@ -1,0 +1,10 @@
+---
+title: "Multilevel Code Construction for Compound Fading Channels"
+collection: publications
+category: conferences
+permalink: /publication/multilevel-code-construction-for-compound-fading-channels
+date: 2017-01-01
+venue: 'ISIT 2017.'
+paperurl: 'https://arxiv.org/abs/1701.08314'
+citation: 'Antonio Campello, Ling Liu and Cong Ling "<a href='https://arxiv.org/abs/1701.08314'>Multilevel Code Construction for Compound Fading Channels</a>", ISIT 2017.'
+---

--- a/_publications/2018-01-01-2d-mimo-radar-with-coprime-arrays.md
+++ b/_publications/2018-01-01-2d-mimo-radar-with-coprime-arrays.md
@@ -1,0 +1,10 @@
+---
+title: "2D MIMO Radar with Coprime Arrays"
+collection: publications
+category: manuscripts
+permalink: /publication/2d-mimo-radar-with-coprime-arrays
+date: 2018-01-01
+venue: 'SAM 2018.'
+paperurl: ''
+citation: 'Conghui Li, Lu Gan and Cong Ling "<a href=''>2D MIMO Radar with Coprime Arrays</a>", SAM 2018.'
+---

--- a/_publications/2018-01-01-algebraic-polar-lattices-for-fast-fading-channels.md
+++ b/_publications/2018-01-01-algebraic-polar-lattices-for-fast-fading-channels.md
@@ -1,0 +1,10 @@
+---
+title: "Algebraic Polar Lattices for Fast Fading Channels"
+collection: publications
+category: manuscripts
+permalink: /publication/algebraic-polar-lattices-for-fast-fading-channels
+date: 2018-01-01
+venue: 'ISTC 2018.'
+paperurl: ''
+citation: 'Ling Liu and Cong Ling "<a href=''>Algebraic Polar Lattices for Fast Fading Channels</a>", ISTC 2018.'
+---

--- a/_publications/2018-01-01-atomic-norm-denoising-based-joint-channel-estimation-and-faulty-antenna-detection-for-massive-mimo.md
+++ b/_publications/2018-01-01-atomic-norm-denoising-based-joint-channel-estimation-and-faulty-antenna-detection-for-massive-mimo.md
@@ -1,0 +1,10 @@
+---
+title: "Atomic Norm Denoising-Based Joint Channel Estimation and Faulty Antenna Detection for Massive MIMO"
+collection: publications
+category: manuscripts
+permalink: /publication/atomic-norm-denoising-based-joint-channel-estimation-and-faulty-antenna-detection-for-massive-mimo
+date: 2018-01-01
+venue: 'IEEE Trans. Veh. Tech.'
+paperurl: 'https://arxiv.org/abs/1709.06832'
+citation: 'Peng Zhang, Lu Gan, Cong Ling, and Sumei Sun "<a href='https://arxiv.org/abs/1709.06832'>Atomic Norm Denoising-Based Joint Channel Estimation and Faulty Antenna Detection for Massive MIMO</a>", IEEE Trans. Veh. Tech., vol. 67, pp. 1389-1403, Feb. 2018.'
+---

--- a/_publications/2018-01-01-performance-limits-of-lattice-reduction-over-imaginary-quadratic-fields-with-applications-to-compute-and-forward.md
+++ b/_publications/2018-01-01-performance-limits-of-lattice-reduction-over-imaginary-quadratic-fields-with-applications-to-compute-and-forward.md
@@ -1,0 +1,10 @@
+---
+title: "Performance Limits of Lattice Reduction over Imaginary Quadratic Fields with Applications to Compute-and-Forward"
+collection: publications
+category: conferences
+permalink: /publication/performance-limits-of-lattice-reduction-over-imaginary-quadratic-fields-with-applications-to-compute-and-forward
+date: 2018-01-01
+venue: 'ITW 2018.'
+paperurl: 'https://arxiv.org/abs/1806.03113'
+citation: 'Shanxiang Lyu, Christian Porter, Cong Ling "<a href='https://arxiv.org/abs/1806.03113'>Performance Limits of Lattice Reduction over Imaginary Quadratic Fields with Applications to Compute-and-Forward</a>", ITW 2018.'
+---

--- a/_publications/2018-01-01-storage-repair-bandwidth-trade-off-for-wireless-caching-with-partial-failure-and-broadcast-repair.md
+++ b/_publications/2018-01-01-storage-repair-bandwidth-trade-off-for-wireless-caching-with-partial-failure-and-broadcast-repair.md
@@ -1,0 +1,10 @@
+---
+title: "Storage-Repair Bandwidth Trade-off for Wireless Caching with Partial Failure and Broadcast Repair"
+collection: publications
+category: conferences
+permalink: /publication/storage-repair-bandwidth-trade-off-for-wireless-caching-with-partial-failure-and-broadcast-repair
+date: 2018-01-01
+venue: 'ITW 2018.'
+paperurl: 'https://arxiv.org/abs/1807.00220'
+citation: 'Nitish Mital, Katina Kralevska, Deniz Gunduz, Cong Ling "<a href='https://arxiv.org/abs/1807.00220'>Storage-Repair Bandwidth Trade-off for Wireless Caching with Partial Failure and Broadcast Repair</a>", ITW 2018.'
+---

--- a/_publications/2020-01-01-coded-computation-against-straggling-channel-decoders-in-the-cloud-for-gaussian-channels.md
+++ b/_publications/2020-01-01-coded-computation-against-straggling-channel-decoders-in-the-cloud-for-gaussian-channels.md
@@ -1,0 +1,10 @@
+---
+title: "Coded Computation Against Straggling Channel Decoders in the Cloud for Gaussian Channels"
+collection: publications
+category: conferences
+permalink: /publication/coded-computation-against-straggling-channel-decoders-in-the-cloud-for-gaussian-channels
+date: 2020-01-01
+venue: 'ISIT 2020.'
+paperurl: 'https://arxiv.org/abs/1805.11698'
+citation: 'Jinwen Shi, Cong Ling, Osvaldo Simeone, Jörg Kliewer "<a href='https://arxiv.org/abs/1805.11698'>Coded Computation Against Straggling Channel Decoders in the Cloud for Gaussian Channels</a>", ISIT 2020.'
+---


### PR DESCRIPTION
## Summary
- mark conference venues like ITW and ISIT as `conferences`
- keep other publications under `manuscripts`

## Testing
- `npm run build:js` *(fails: uglifyjs not found)*
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68486ebe5be8832b94c1581cf8f6c38f