### PR TITLE
Fix conference categories for publication posts

### DIFF
--- a/_publications/1900-01-01-multi-dimensional-nested-lattice-quantization-for-wyner-ziv-coding.md
+++ b/_publications/1900-01-01-multi-dimensional-nested-lattice-quantization-for-wyner-ziv-coding.md
@@ -1,7 +1,7 @@
 ---
 title: "Multi-dimensional nested lattice quantization for Wyner-Ziv coding"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/multi-dimensional-nested-lattice-quantization-for-wyner-ziv-coding
 date: 1900-01-01
 venue: 'ICC’09'

--- a/_publications/1900-01-01-near-optimal-relaying-strategy-for-cooperative-broadcast-channel.md
+++ b/_publications/1900-01-01-near-optimal-relaying-strategy-for-cooperative-broadcast-channel.md
@@ -1,7 +1,7 @@
 ---
 title: "Near-optimal relaying strategy for cooperative broadcast channel"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/near-optimal-relaying-strategy-for-cooperative-broadcast-channel
 date: 1900-01-01
 venue: 'ICC’09'

--- a/_publications/2002-01-01-despreading-chip-waveform-design-for-coherent-delay-locked-tracking-in-ds-ss-systems.md
+++ b/_publications/2002-01-01-despreading-chip-waveform-design-for-coherent-delay-locked-tracking-in-ds-ss-systems.md
@@ -1,7 +1,7 @@
 ---
 title: "Despreading chip waveform design for coherent delay-locked tracking in DS/SS systems"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/despreading-chip-waveform-design-for-coherent-delay-locked-tracking-in-ds-ss-systems
 date: 2002-01-01
 venue: 'in Proc. ICC’2002'

--- a/_publications/2002-01-01-linear-prediction-receiver-for-differential-space-time-modulation-over-time-correlated-rayleigh-fading-channels.md
+++ b/_publications/2002-01-01-linear-prediction-receiver-for-differential-space-time-modulation-over-time-correlated-rayleigh-fading-channels.md
@@ -1,7 +1,7 @@
 ---
 title: "Linear prediction receiver for differential space-time modulation over time-correlated Rayleigh fading channels"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/linear-prediction-receiver-for-differential-space-time-modulation-over-time-correlated-rayleigh-fading-channels
 date: 2002-01-01
 venue: 'in Proc. ICC’2002'

--- a/_publications/2003-01-01-on-decision-feedback-detection-of-nondiagonal-differential-space-time-modulation-in-temporally-correlated-fading-channels.md
+++ b/_publications/2003-01-01-on-decision-feedback-detection-of-nondiagonal-differential-space-time-modulation-in-temporally-correlated-fading-channels.md
@@ -1,7 +1,7 @@
 ---
 title: "On Decision-Feedback Detection of Nondiagonal Differential Space-Time Modulation in Temporally Correlated Fading Channels"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/on-decision-feedback-detection-of-nondiagonal-differential-space-time-modulation-in-temporally-correlated-fading-channels
 date: 2003-01-01
 venue: 'in Proc. ICC’03'

--- a/_publications/2004-01-01-gallager-bounds-for-space-time-codes.md
+++ b/_publications/2004-01-01-gallager-bounds-for-space-time-codes.md
@@ -1,7 +1,7 @@
 ---
 title: "Gallager bounds for space-time codes"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/gallager-bounds-for-space-time-codes
 date: 2004-01-01
 venue: 'IEEE Communication Theory Workshop 2004'

--- a/_publications/2005-01-01-differential-lattice-decoding-in-noncoherent-mimo-communication.md
+++ b/_publications/2005-01-01-differential-lattice-decoding-in-noncoherent-mimo-communication.md
@@ -1,7 +1,7 @@
 ---
 title: "Differential lattice decoding in noncoherent MIMO communication"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/differential-lattice-decoding-in-noncoherent-mimo-communication
 date: 2005-01-01
 venue: 'ICC’05'

--- a/_publications/2006-01-01-a-dual-lattice-view-of-v-blast-detection.md
+++ b/_publications/2006-01-01-a-dual-lattice-view-of-v-blast-detection.md
@@ -1,7 +1,7 @@
 ---
 title: "A dual-lattice view of V-BLAST detection"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/a-dual-lattice-view-of-v-blast-detection
 date: 2006-01-01
 venue: 'IEEE Inform. Theory Workshop'

--- a/_publications/2006-01-01-approximate-lattice-decoding-primal-versus-dual-basis-reduction.md
+++ b/_publications/2006-01-01-approximate-lattice-decoding-primal-versus-dual-basis-reduction.md
@@ -1,7 +1,7 @@
 ---
 title: "Approximate lattice decoding: Primal versus dual basis reduction"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/approximate-lattice-decoding-primal-versus-dual-basis-reduction
 date: 2006-01-01
 venue: 'IEEE Int. Symp. Inform. Theory’06'

--- a/_publications/2006-01-01-gallager-bounds-for-space-time-codes-in-quasi-static-fading-channels.md
+++ b/_publications/2006-01-01-gallager-bounds-for-space-time-codes-in-quasi-static-fading-channels.md
@@ -1,7 +1,7 @@
 ---
 title: "Gallager bounds for space-time codes in quasi-static fading channels"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/gallager-bounds-for-space-time-codes-in-quasi-static-fading-channels
 date: 2006-01-01
 venue: 'IEEE Inform. Theory Workshop'

--- a/_publications/2006-01-01-towards-characterizing-the-performance-of-approximate-lattice-decoding-in-mimo-communications.md
+++ b/_publications/2006-01-01-towards-characterizing-the-performance-of-approximate-lattice-decoding-in-mimo-communications.md
@@ -1,7 +1,7 @@
 ---
 title: "Towards characterizing the performance of approximate lattice decoding in MIMO communications"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/towards-characterizing-the-performance-of-approximate-lattice-decoding-in-mimo-communications
 date: 2006-01-01
 venue: 'Int. Symp. Turbo Codes / Int. ITG Conf. Source Channel Coding’06'

--- a/_publications/2007-01-01-effective-lll-reduction-for-lattice-decoding.md
+++ b/_publications/2007-01-01-effective-lll-reduction-for-lattice-decoding.md
@@ -1,7 +1,7 @@
 ---
 title: "Effective LLL reduction for lattice decoding"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/effective-lll-reduction-for-lattice-decoding
 date: 2007-01-01
 venue: 'IEEE Int. Symp. Inform. Theory’07'

--- a/_publications/2007-01-01-towards-understanding-weighted-bit-flipping-decoding.md
+++ b/_publications/2007-01-01-towards-understanding-weighted-bit-flipping-decoding.md
@@ -1,7 +1,7 @@
 ---
 title: "Towards understanding weighted bit-flipping decoding"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/towards-understanding-weighted-bit-flipping-decoding
 date: 2007-01-01
 venue: 'IEEE Int. Symp. Inform. Theory’07'

--- a/_publications/2009-01-01-a-unified-view-of-sorting-in-lattice-reduction-from-v-blast-to-lll-and-beyond.md
+++ b/_publications/2009-01-01-a-unified-view-of-sorting-in-lattice-reduction-from-v-blast-to-lll-and-beyond.md
@@ -1,7 +1,7 @@
 ---
 title: "A unified view of sorting in lattice reduction: From V-BLAST to LLL and beyond"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/a-unified-view-of-sorting-in-lattice-reduction-from-v-blast-to-lll-and-beyond
 date: 2009-01-01
 venue: 'IEEE Inform. Theory Workshop 2009'

--- a/_publications/2009-01-01-active-physical-layer-network-coding-for-cooperative-two-way-relay-channels.md
+++ b/_publications/2009-01-01-active-physical-layer-network-coding-for-cooperative-two-way-relay-channels.md
@@ -1,7 +1,7 @@
 ---
 title: "Active physical-layer network coding for cooperative two-way relay channels"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/active-physical-layer-network-coding-for-cooperative-two-way-relay-channels
 date: 2009-01-01
 venue: 'Second IEEE International Workshop on Wireless Network Coding'

--- a/_publications/2009-01-01-statistical-restricted-isometry-property-of-orthogonal-symmetric-toeplitz-matrices.md
+++ b/_publications/2009-01-01-statistical-restricted-isometry-property-of-orthogonal-symmetric-toeplitz-matrices.md
@@ -1,7 +1,7 @@
 ---
 title: "Statistical restricted isometry property of orthogonal symmetric Toeplitz matrices"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/statistical-restricted-isometry-property-of-orthogonal-symmetric-toeplitz-matrices
 date: 2009-01-01
 venue: 'IEEE Inform. Theory Workshop 2009'

--- a/_publications/2010-01-01-randomized-lattice-decoding-bridging-the-gap-between-lattice-reduction-and-sphere-decoding.md
+++ b/_publications/2010-01-01-randomized-lattice-decoding-bridging-the-gap-between-lattice-reduction-and-sphere-decoding.md
@@ -1,7 +1,7 @@
 ---
 title: "Randomized lattice decoding: Bridging the gap between lattice reduction and sphere decoding"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/randomized-lattice-decoding-bridging-the-gap-between-lattice-reduction-and-sphere-decoding
 date: 2010-01-01
 venue: 'IEEE Int. Symp. Inform. Theory’10'

--- a/_publications/2010-01-01-relay-aided-interference-alignment-feasibility-conditions-and-algorithm.md
+++ b/_publications/2010-01-01-relay-aided-interference-alignment-feasibility-conditions-and-algorithm.md
@@ -1,7 +1,7 @@
 ---
 title: "Relay-aided interference alignment: Feasibility conditions and algorithm"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/relay-aided-interference-alignment-feasibility-conditions-and-algorithm
 date: 2010-01-01
 venue: 'IEEE Int. Symp. Inform. Theory’10'

--- a/_publications/2011-01-01-achievable-rates-for-lattice-coding-over-the-gaussian-wiretap-channel.md
+++ b/_publications/2011-01-01-achievable-rates-for-lattice-coding-over-the-gaussian-wiretap-channel.md
@@ -1,7 +1,7 @@
 ---
 title: "Achievable rates for lattice coding over the Gaussian wiretap channel"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/achievable-rates-for-lattice-coding-over-the-gaussian-wiretap-channel
 date: 2011-01-01
 venue: 'ICC 2011 Physical Layer Security Workshop.'

--- a/_publications/2011-01-01-secrecy-gain-of-trellis-codes-the-other-side-of-the-union-bound.md
+++ b/_publications/2011-01-01-secrecy-gain-of-trellis-codes-the-other-side-of-the-union-bound.md
@@ -1,7 +1,7 @@
 ---
 title: "Secrecy gain of trellis codes: The other side of the union bound"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/secrecy-gain-of-trellis-codes-the-other-side-of-the-union-bound
 date: 2011-01-01
 venue: 'ITW 2011'

--- a/_publications/2012-01-01-a-construction-of-lattices-from-polar-codes.md
+++ b/_publications/2012-01-01-a-construction-of-lattices-from-polar-codes.md
@@ -1,7 +1,7 @@
 ---
 title: "A construction of lattices from polar codes"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/a-construction-of-lattices-from-polar-codes
 date: 2012-01-01
 venue: 'IEEE Inform. Theory Workshop 2012.'

--- a/_publications/2012-01-01-analysis-of-lattice-codes-for-the-many-to-one-interference-channel.md
+++ b/_publications/2012-01-01-analysis-of-lattice-codes-for-the-many-to-one-interference-channel.md
@@ -1,7 +1,7 @@
 ---
 title: "Analysis of lattice codes for the many-to-one interference channel"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/analysis-of-lattice-codes-for-the-many-to-one-interference-channel
 date: 2012-01-01
 venue: 'IEEE Inform. Theory Workshop 2012.'

--- a/_publications/2012-01-01-derandomized-sampling-algorithm-for-lattice-decoding.md
+++ b/_publications/2012-01-01-derandomized-sampling-algorithm-for-lattice-decoding.md
@@ -1,7 +1,7 @@
 ---
 title: "Derandomized sampling algorithm for lattice decoding"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/derandomized-sampling-algorithm-for-lattice-decoding
 date: 2012-01-01
 venue: 'IEEE Inform. Theory Workshop 2012.'

--- a/_publications/2012-01-01-golay-meets-hadamard-golay-paired-hadamard-matrices-for-fast-compressed-sensing.md
+++ b/_publications/2012-01-01-golay-meets-hadamard-golay-paired-hadamard-matrices-for-fast-compressed-sensing.md
@@ -1,7 +1,7 @@
 ---
 title: "Golay meets Hadamard: Golay-paired Hadamard matrices for fast compressed sensing"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/golay-meets-hadamard-golay-paired-hadamard-matrices-for-fast-compressed-sensing
 date: 2012-01-01
 venue: 'IEEE Inform. Theory Workshop 2012.'

--- a/_publications/2012-01-01-lattice-codes-achieving-strong-secrecy-over-the-mod-l-gaussian-channel.md
+++ b/_publications/2012-01-01-lattice-codes-achieving-strong-secrecy-over-the-mod-l-gaussian-channel.md
@@ -1,7 +1,7 @@
 ---
 title: "Lattice codes achieving strong secrecy over the mod-L Gaussian channel"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/lattice-codes-achieving-strong-secrecy-over-the-mod-l-gaussian-channel
 date: 2012-01-01
 venue: 'ISIT 2012.'

--- a/_publications/2012-01-01-novel-toeptlitz-sensing-matrices-for-compressive-radar-imaging.md
+++ b/_publications/2012-01-01-novel-toeptlitz-sensing-matrices-for-compressive-radar-imaging.md
@@ -1,7 +1,7 @@
 ---
 title: "Novel Toeptlitz sensing matrices for compressive radar imaging"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/novel-toeptlitz-sensing-matrices-for-compressive-radar-imaging
 date: 2012-01-01
 venue: '1st International Workshop on Compressed Sensing applied to Radar'

--- a/_publications/2012-01-01-proximity-factors-of-lattice-reduction-aided-precoding-for-multiantenna-broadcast.md
+++ b/_publications/2012-01-01-proximity-factors-of-lattice-reduction-aided-precoding-for-multiantenna-broadcast.md
@@ -1,7 +1,7 @@
 ---
 title: "Proximity factors of lattice reduction-aided precoding for multiantenna broadcast"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/proximity-factors-of-lattice-reduction-aided-precoding-for-multiantenna-broadcast
 date: 2012-01-01
 venue: 'ISIT 2012.'

--- a/_publications/2012-01-01-reliable-sub-nyquist-wideband-spectrum-sensing-based-on-randomised-sampling.md
+++ b/_publications/2012-01-01-reliable-sub-nyquist-wideband-spectrum-sensing-based-on-randomised-sampling.md
@@ -1,7 +1,7 @@
 ---
 title: "Reliable sub-Nyquist wideband spectrum sensing based on randomised sampling"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/reliable-sub-nyquist-wideband-spectrum-sensing-based-on-randomised-sampling
 date: 2012-01-01
 venue: '1st International Workshop on Compressed Sensing applied to Radar'

--- a/_publications/2012-01-01-the-flatness-factor-in-lattice-network-coding-design-criterion-and-decoding-algorithm.md
+++ b/_publications/2012-01-01-the-flatness-factor-in-lattice-network-coding-design-criterion-and-decoding-algorithm.md
@@ -1,7 +1,7 @@
 ---
 title: "The flatness factor in lattice network coding: Design criterion and decoding algorithm"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/the-flatness-factor-in-lattice-network-coding-design-criterion-and-decoding-algorithm
 date: 2012-01-01
 venue: 'International Zurich Seminar on Communications 2012'

--- a/_publications/2013-01-01-achieving-the-awgn-channel-capacity-with-lattice-gaussian-distribution.md
+++ b/_publications/2013-01-01-achieving-the-awgn-channel-capacity-with-lattice-gaussian-distribution.md
@@ -1,7 +1,7 @@
 ---
 title: "Achieving the AWGN channel capacity with lattice Gaussian distribution"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/achieving-the-awgn-channel-capacity-with-lattice-gaussian-distribution
 date: 2013-01-01
 venue: 'ISIT 2013.'

--- a/_publications/2013-01-01-barnes-wall-lattices-for-symmetric-interference-channel.md
+++ b/_publications/2013-01-01-barnes-wall-lattices-for-symmetric-interference-channel.md
@@ -1,7 +1,7 @@
 ---
 title: "Barnes-Wall lattices for symmetric interference channel"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/barnes-wall-lattices-for-symmetric-interference-channel
 date: 2013-01-01
 venue: 'ISIT 2013.'

--- a/_publications/2013-01-01-lattice-quantization-noise-revisited.md
+++ b/_publications/2013-01-01-lattice-quantization-noise-revisited.md
@@ -1,7 +1,7 @@
 ---
 title: "Lattice quantization noise revisited"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/lattice-quantization-noise-revisited
 date: 2013-01-01
 venue: 'IEEE Inform. Theory Workshop 2013.'

--- a/_publications/2013-01-01-polar-lattices-where-arikan-meets-forney.md
+++ b/_publications/2013-01-01-polar-lattices-where-arikan-meets-forney.md
@@ -1,7 +1,7 @@
 ---
 title: "Polar lattices: Where Arikan meets Forney"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/polar-lattices-where-arikan-meets-forney
 date: 2013-01-01
 venue: 'ISIT 2013.'

--- a/_publications/2013-01-01-secret-key-generation-from-gaussian-sources-using-lattice-hashing.md
+++ b/_publications/2013-01-01-secret-key-generation-from-gaussian-sources-using-lattice-hashing.md
@@ -1,7 +1,7 @@
 ---
 title: "Secret key generation from Gaussian sources using lattice hashing"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/secret-key-generation-from-gaussian-sources-using-lattice-hashing
 date: 2013-01-01
 venue: 'ISIT 2013.'

--- a/_publications/2014-01-01-achievable-diversity-rate-tradeoff-of-mimo-af-relaying-systems-with-mmse-transceivers.md
+++ b/_publications/2014-01-01-achievable-diversity-rate-tradeoff-of-mimo-af-relaying-systems-with-mmse-transceivers.md
@@ -1,7 +1,7 @@
 ---
 title: "Achievable Diversity-Rate Tradeoff of MIMO AF Relaying Systems with MMSE Transceivers"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/achievable-diversity-rate-tradeoff-of-mimo-af-relaying-systems-with-mmse-transceivers
 date: 2014-01-01
 venue: 'ISIT 2014.'

--- a/_publications/2014-01-01-lattice-gaussian-coding-for-capacity-and-secrecy-two-sides-of-one-coin.md
+++ b/_publications/2014-01-01-lattice-gaussian-coding-for-capacity-and-secrecy-two-sides-of-one-coin.md
@@ -1,7 +1,7 @@
 ---
 title: "Lattice Gaussian Coding for Capacity and Secrecy: Two Sides of One Coin"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/lattice-gaussian-coding-for-capacity-and-secrecy-two-sides-of-one-coin
 date: 2014-01-01
 venue: 'International Zurich Seminar on Communications 2014 (invited paper).'

--- a/_publications/2014-01-01-markov-chain-monte-carlo-algorithms-for-lattice-gaussian-sampling.md
+++ b/_publications/2014-01-01-markov-chain-monte-carlo-algorithms-for-lattice-gaussian-sampling.md
@@ -1,7 +1,7 @@
 ---
 title: "Markov Chain Monte Carlo Algorithms for Lattice Gaussian Sampling"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/markov-chain-monte-carlo-algorithms-for-lattice-gaussian-sampling
 date: 2014-01-01
 venue: 'ISIT 2014.'

--- a/_publications/2014-01-01-polar-lattices-for-strong-secrecy-over-the-mod-lambda-gaussian-wiretap-channel.md
+++ b/_publications/2014-01-01-polar-lattices-for-strong-secrecy-over-the-mod-lambda-gaussian-wiretap-channel.md
@@ -1,7 +1,7 @@
 ---
 title: "Polar Lattices for Strong Secrecy Over the Mod-Lambda Gaussian Wiretap Channel"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/polar-lattices-for-strong-secrecy-over-the-mod-lambda-gaussian-wiretap-channel
 date: 2014-01-01
 venue: 'ISIT 2014.'

--- a/_publications/2014-01-01-secrecy-gain-flatness-factor-and-secrecy-goodness-of-even-unimodular-lattices.md
+++ b/_publications/2014-01-01-secrecy-gain-flatness-factor-and-secrecy-goodness-of-even-unimodular-lattices.md
@@ -1,7 +1,7 @@
 ---
 title: "Secrecy gain, flatness factor, and secrecy-goodness of even unimodular lattices"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/secrecy-gain-flatness-factor-and-secrecy-goodness-of-even-unimodular-lattices
 date: 2014-01-01
 venue: 'ISIT 2014.'

--- a/_publications/2014-01-01-superposition-lattice-coding-for-gaussian-broadcast-channel-with-confidential-message.md
+++ b/_publications/2014-01-01-superposition-lattice-coding-for-gaussian-broadcast-channel-with-confidential-message.md
@@ -1,7 +1,7 @@
 ---
 title: "Superposition Lattice Coding for Gaussian Broadcast Channel with Confidential Message"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/superposition-lattice-coding-for-gaussian-broadcast-channel-with-confidential-message
 date: 2014-01-01
 venue: 'IEEE Inform. Theory Workshop 2014 (invited paper).'

--- a/_publications/2014-01-01-variable-density-sampling-on-the-dual-lattice.md
+++ b/_publications/2014-01-01-variable-density-sampling-on-the-dual-lattice.md
@@ -1,7 +1,7 @@
 ---
 title: "Variable-Density Sampling on the Dual Lattice"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/variable-density-sampling-on-the-dual-lattice
 date: 2014-01-01
 venue: 'ISIT 2014.'

--- a/_publications/2015-01-01-atomic-norm-denoising-based-channel-estimation-for-massive-multiuser-mimo-systems.md
+++ b/_publications/2015-01-01-atomic-norm-denoising-based-channel-estimation-for-massive-multiuser-mimo-systems.md
@@ -1,7 +1,7 @@
 ---
 title: "Atomic Norm Denoising-based Channel Estimation for Massive Multiuser MIMO Systems"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/atomic-norm-denoising-based-channel-estimation-for-massive-multiuser-mimo-systems
 date: 2015-01-01
 venue: 'ICC 2015.'

--- a/_publications/2015-01-01-independent-metropolis-hastings-klein-algorithm-for-lattice-gaussian-sampling.md
+++ b/_publications/2015-01-01-independent-metropolis-hastings-klein-algorithm-for-lattice-gaussian-sampling.md
@@ -1,7 +1,7 @@
 ---
 title: "Independent Metropolis-Hastings-Klein Algorithm for Lattice Gaussian Sampling"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/independent-metropolis-hastings-klein-algorithm-for-lattice-gaussian-sampling
 date: 2015-01-01
 venue: 'ISIT 2015.'

--- a/_publications/2015-01-01-nested-array-with-time-delayers-for-target-range-and-angle-estimation.md
+++ b/_publications/2015-01-01-nested-array-with-time-delayers-for-target-range-and-angle-estimation.md
@@ -1,7 +1,7 @@
 ---
 title: "Nested Array With Time-Delayers for Target Range and Angle Estimation"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/nested-array-with-time-delayers-for-target-range-and-angle-estimation
 date: 2015-01-01
 venue: '3rd International Workshop on Compressed Sensing Theory and its Applications to Radar'

--- a/_publications/2016-01-01-achieving-capacity-and-security-in-wireless-communications-with-lattice-codes.md
+++ b/_publications/2016-01-01-achieving-capacity-and-security-in-wireless-communications-with-lattice-codes.md
@@ -1,7 +1,7 @@
 ---
 title: "Achieving Capacity and Security in Wireless Communications With Lattice Codes"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/achieving-capacity-and-security-in-wireless-communications-with-lattice-codes
 date: 2016-01-01
 venue: 'International Symposium on Turbo Codes 2016.'

--- a/_publications/2016-01-01-algebraic-lattice-codes-achieve-the-capacity-of-the-compound-block-fading-channel.md
+++ b/_publications/2016-01-01-algebraic-lattice-codes-achieve-the-capacity-of-the-compound-block-fading-channel.md
@@ -1,7 +1,7 @@
 ---
 title: "Algebraic Lattice Codes Achieve the Capacity of the Compound Block-Fading Channel"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/algebraic-lattice-codes-achieve-the-capacity-of-the-compound-block-fading-channel
 date: 2016-01-01
 venue: 'ISIT 2016.'

--- a/_publications/2016-01-01-algebraic-lattices-achieve-the-capacity-of-the-ergodic-fading-channel.md
+++ b/_publications/2016-01-01-algebraic-lattices-achieve-the-capacity-of-the-ergodic-fading-channel.md
@@ -1,7 +1,7 @@
 ---
 title: "Algebraic lattices achieve the capacity of the ergodic fading channel"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/algebraic-lattices-achieve-the-capacity-of-the-ergodic-fading-channel
 date: 2016-01-01
 venue: 'ITW 2016.'

--- a/_publications/2016-01-01-almost-universal-codes-for-fading-wiretap-channels.md
+++ b/_publications/2016-01-01-almost-universal-codes-for-fading-wiretap-channels.md
@@ -1,7 +1,7 @@
 ---
 title: "Almost universal codes for fading wiretap channels"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/almost-universal-codes-for-fading-wiretap-channels
 date: 2016-01-01
 venue: 'ISIT 2016.'

--- a/_publications/2016-01-01-further-results-on-independent-metropolis-hastings-klein-sampling.md
+++ b/_publications/2016-01-01-further-results-on-independent-metropolis-hastings-klein-sampling.md
@@ -1,7 +1,7 @@
 ---
 title: "Further Results on Independent Metropolis-Hastings-Klein Sampling"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/further-results-on-independent-metropolis-hastings-klein-sampling
 date: 2016-01-01
 venue: 'ISIT 2016.'

--- a/_publications/2016-01-01-symmetric-mettropolis-within-gibbs-algorithm-for-lattice-gaussian-sampling.md
+++ b/_publications/2016-01-01-symmetric-mettropolis-within-gibbs-algorithm-for-lattice-gaussian-sampling.md
@@ -1,7 +1,7 @@
 ---
 title: "Symmetric Mettropolis-within-Gibbs Algorithm for Lattice Gaussian Sampling"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/symmetric-mettropolis-within-gibbs-algorithm-for-lattice-gaussian-sampling
 date: 2016-01-01
 venue: 'ITW 2016.'

--- a/_publications/2017-01-01-compute-and-forward-over-block-fading-channels-using-algebraic-lattices.md
+++ b/_publications/2017-01-01-compute-and-forward-over-block-fading-channels-using-algebraic-lattices.md
@@ -1,7 +1,7 @@
 ---
 title: "Compute-and-Forward over Block-Fading Channels Using Algebraic Lattices"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/compute-and-forward-over-block-fading-channels-using-algebraic-lattices
 date: 2017-01-01
 venue: 'ISIT 2017.'

--- a/_publications/2017-01-01-multilevel-code-construction-for-compound-fading-channels.md
+++ b/_publications/2017-01-01-multilevel-code-construction-for-compound-fading-channels.md
@@ -1,7 +1,7 @@
 ---
 title: "Multilevel Code Construction for Compound Fading Channels"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/multilevel-code-construction-for-compound-fading-channels
 date: 2017-01-01
 venue: 'ISIT 2017.'

--- a/_publications/2018-01-01-performance-limits-of-lattice-reduction-over-imaginary-quadratic-fields-with-applications-to-compute-and-forward.md
+++ b/_publications/2018-01-01-performance-limits-of-lattice-reduction-over-imaginary-quadratic-fields-with-applications-to-compute-and-forward.md
@@ -1,7 +1,7 @@
 ---
 title: "Performance Limits of Lattice Reduction over Imaginary Quadratic Fields with Applications to Compute-and-Forward"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/performance-limits-of-lattice-reduction-over-imaginary-quadratic-fields-with-applications-to-compute-and-forward
 date: 2018-01-01
 venue: 'ITW 2018.'

--- a/_publications/2018-01-01-storage-repair-bandwidth-trade-off-for-wireless-caching-with-partial-failure-and-broadcast-repair.md
+++ b/_publications/2018-01-01-storage-repair-bandwidth-trade-off-for-wireless-caching-with-partial-failure-and-broadcast-repair.md
@@ -1,7 +1,7 @@
 ---
 title: "Storage-Repair Bandwidth Trade-off for Wireless Caching with Partial Failure and Broadcast Repair"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/storage-repair-bandwidth-trade-off-for-wireless-caching-with-partial-failure-and-broadcast-repair
 date: 2018-01-01
 venue: 'ITW 2018.'

--- a/_publications/2020-01-01-coded-computation-against-straggling-channel-decoders-in-the-cloud-for-gaussian-channels.md
+++ b/_publications/2020-01-01-coded-computation-against-straggling-channel-decoders-in-the-cloud-for-gaussian-channels.md
@@ -1,7 +1,7 @@
 ---
 title: "Coded Computation Against Straggling Channel Decoders in the Cloud for Gaussian Channels"
 collection: publications
-category: manuscripts
+category: conference
 permalink: /publication/coded-computation-against-straggling-channel-decoders-in-the-cloud-for-gaussian-channels
 date: 2020-01-01
 venue: 'ISIT 2020.'


### PR DESCRIPTION
## Summary
- update categories to `conference` for publications mentioning conference venues

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684887c244d0832b9a99641869849032