### PR TITLE
Add publication update workflow

### DIFF
--- a/.github/workflows/run_markdown_generator.yml
+++ b/.github/workflows/run_markdown_generator.yml
@@ -1,0 +1,36 @@
+name: Run Markdown Generator
+
+on:
+  push:
+    paths:
+      - 'markdown_generator/**'
+      - 'files/*.bib'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+
+      - name: Install dependencies
+        run: |
+          pip install pandas pybtex
+
+      - name: Run pub generator
+        working-directory: markdown_generator
+        run: |
+          python pubsFromBib.py
+
+      - name: Commit changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add _publications/*.md
+          git commit -m "Automated update from markdown generator" || echo "No changes to commit"
+          git push

--- a/markdown_generator/pubsFromBib.py
+++ b/markdown_generator/pubsFromBib.py
@@ -27,7 +27,8 @@ import re
 #todo: incorporate different collection types rather than a catch all publications, requires other changes to template
 publist = {
     "proceeding": {
-        "file" : "proceedings.bib",
+        # use repository sample bib file
+        "file" : "../files/bibtex1.bib",
         "venuekey": "booktitle",
         "venue-pretext": "In the proceedings of ",
         "collection" : {"name":"publications",
@@ -35,7 +36,8 @@ publist = {
         
     },
     "journal":{
-        "file": "pubs.bib",
+        # same sample bib file covers journal articles
+        "file": "../files/bibtex1.bib",
         "venuekey" : "journal",
         "venue-pretext" : "",
         "collection" : {"name":"publications",


### PR DESCRIPTION
## Summary
- add a workflow that runs the publication markdown generator
- fix workflow path
- update pubsFromBib script with sample bib location

## Testing
- `python markdown_generator/pubsFromBib.py` *(fails: ModuleNotFoundError: No module named 'pybtex')*


------
https://chatgpt.com/codex/tasks/task_e_6848998977e8832b8b7e1e3b9f6199a8