### PR TITLE
Fix publication metadata

### DIFF
--- a/_publications/2025-06-08-paper-title-number-5.md
+++ b/_publications/2025-06-08-paper-title-number-5.md
@@ -2,12 +2,12 @@
 title: "Paper Title Number 5, with math $$E=mc^2$$"
 collection: publications
 category: conferences
-permalink: /publication/2024-02-17-paper-title-number-4
+permalink: /publication/2025-06-08-paper-title-number-5
 excerpt: 'This paper is about a famous math equation, $$E=mc^2$$'
-date: 201-02-17
+date: 2025-06-08
 venue: 'GitHub Journal of Bugs'
 paperurl: 'http://academicpages.github.io/files/paper3.pdf'
-citation: 'Your Name, You. (2024). &quot;Paper Title Number 3.&quot; <i>GitHub Journal of Bugs</i>. 1(3).'
+citation: 'Your Name, You. (2025). &quot;Paper Title Number 5.&quot; <i>GitHub Journal of Bugs</i>. 1(3).'
 ---
 
 Using [MathJax](https://www.mathjax.org/) in the description is supported - $$E=mc^2$$ - however, the use must be mindful that the default delimiters are `$$...$$` and `\\[...\\]` which differs from the `$...$` that is typically expected.


### PR DESCRIPTION
## Summary
- correct the date and permalink for sample conference paper

## Testing
- `bundle exec jekyll build` *(fails: `bundler: command not found: jekyll`)*

------
https://chatgpt.com/codex/tasks/task_e_6848ace63a74832b84a67e8c8a131831