### PR TITLE
Show citation at top of publication page

### DIFF
--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -26,7 +26,11 @@ layout: default
     <div class="page__inner-wrap">
       {% unless page.header.overlay_color or page.header.overlay_image %}
         <header>
-          {% if page.title %}<h1 class="page__title" itemprop="headline">{{ page.title | markdownify | remove: "<p>" | remove: "</p>" }}</h1>{% endif %}
+          {% if page.collection == 'publications' and page.citation %}
+            <h1 class="page__title" itemprop="headline">{{ page.citation }}</h1>
+          {% elsif page.title %}
+            <h1 class="page__title" itemprop="headline">{{ page.title | markdownify | remove: "<p>" | remove: "</p>" }}</h1>
+          {% endif %}
           {% if page.read_time %}
             <p class="page__meta"><i class="fa fa-clock" aria-hidden="true"></i> {% include read-time.html %}</p>
           {% endif %}


### PR DESCRIPTION
## Summary
- use citation as heading for single publication pages so the authors appear first

## Testing
- `bundle exec jekyll build` *(fails: bundler not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68496704b8e8832bb7908f59637336fc